### PR TITLE
refactor(gtkwave): build groups from trace positions instead of name regexes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
+      # The gtkwave target emits TCL, and the quoting tests check it by
+      # running it. They skip themselves when tclsh is missing, so without
+      # this the runner image silently decides whether they run at all.
+      - name: Install tclsh
+        run: sudo apt-get install -y --no-install-recommends tcl
+
       - name: Run pytest
         run: uv run --group dev pytest
 

--- a/tests/test_group_spans.py
+++ b/tests/test_group_spans.py
@@ -1,0 +1,92 @@
+"""Structural tests for the index-based gtkwave grouping.
+
+Groups used to be built by highlighting their members with a regex on the
+displayed trace name. That could not work for comment rows -- they have no
+signal name -- so dividers fell out of every group, and it could not name a
+signal reliably either, since gtkwave shows a one-bit signal as `name[0]`
+and a bus as `name[hi:lo]`.
+
+The target now records the trace count before a group's contents and
+highlights every row that appeared. These tests pin that structure: what
+gtkwave then does with it can only be checked in the viewer.
+"""
+
+import unittest
+
+from wavedisp.ast import Block, Disp, Divider, Group
+from wavedisp.targets.gtkwave import GTKWaveTarget
+
+
+def generate(tree):
+    return GTKWaveTarget(tree).genstr
+
+
+class TestGroupSpans(unittest.TestCase):
+    def test_no_regex_matching_is_emitted(self):
+        """The whole point: names are never matched, only positions."""
+        blk = Block()
+        grp = blk.add(Group("g"))
+        grp.add(Disp("sig", radix="hexadecimal", color="red"))
+        out = generate(blk)
+        self.assertNotIn("Highlight_Regexp", out)
+        self.assertIn("setTraceHighlightFromIndex", out)
+
+    def test_divider_is_inside_the_group_span(self):
+        """A comment row is captured like any other row.
+
+        This is what the regex approach could not do at all.
+        """
+        blk = Block()
+        grp = blk.add(Group("g"))
+        grp.add(Divider("section"))
+        grp.add(Disp("sig"))
+        out = generate(blk)
+        start = out.index("set wd_start_0")
+        comment = out.index("Insert_Comment {section}")
+        create = out.index("Create_Group {g}")
+        self.assertLess(start, comment)
+        self.assertLess(comment, create)
+
+    def test_nested_groups_use_distinct_variables(self):
+        """An inner group is created inside the outer one's span."""
+        blk = Block()
+        outer = blk.add(Group("outer"))
+        inner = outer.add(Group("inner"))
+        inner.add(Disp("sig"))
+        out = generate(blk)
+        self.assertIn("set wd_start_0", out)
+        self.assertIn("set wd_start_1", out)
+        self.assertLess(out.index("Create_Group {inner}"), out.index("Create_Group {outer}"))
+        # the outer span is read after the inner group was created, so the
+        # rows it added are part of it
+        self.assertLess(out.index("set wd_start_0"), out.index("set wd_start_1"))
+
+    def test_group_creation_is_guarded_on_the_count(self):
+        """An empty group must not be created."""
+        blk = Block()
+        blk.add(Group("empty"))
+        out = generate(blk)
+        self.assertIn("if {[gtkwave::getTotalNumTraces] > $wd_start_0}", out)
+
+    def test_property_targets_only_what_the_add_produced(self):
+        """A missing signal adds nothing, so the property applies to nothing."""
+        blk = Block()
+        blk.add(Disp("sig", radix="hexadecimal"))
+        out = generate(blk)
+        self.assertLess(out.index("set wd_sig"), out.index("addSignalsFromList"))
+        self.assertLess(out.index("addSignalsFromList"), out.index("Data_Format/Hex"))
+
+    def test_no_counter_without_a_property(self):
+        blk = Block()
+        blk.add(Disp("sig"))
+        self.assertNotIn("set wd_sig", generate(blk))
+
+    def test_nothing_is_left_highlighted(self):
+        blk = Block()
+        blk.add(Disp("sig"))
+        self.assertTrue(generate(blk).rstrip().endswith("Set_Trace_Max_Hier 1"))
+        self.assertIn("UnHighlight_All\ngtkwave::/Edit/Set_Trace_Max_Hier 1", generate(blk))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_target_gtkwave.py
+++ b/tests/test_target_gtkwave.py
@@ -32,71 +32,135 @@ gtkwave::addSignalsFromList [list {tb.top.clock_main}]
 gtkwave::addSignalsFromList [list {tb.top.external_pll_valid}]
 gtkwave::/Edit/Insert_Comment {The divider}
 
+set wd_start_0 [gtkwave::getTotalNumTraces]
+set wd_sig [gtkwave::getTotalNumTraces]
 gtkwave::addSignalsFromList [list {tb.top.reset_inst/pcie_rstn}]
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reset_inst/pcie_rstn}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Data_Format/Binary
 gtkwave::/Edit/UnHighlight_All
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reset_inst/pcie_rstn}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Color_Format/Red
 gtkwave::/Edit/UnHighlight_All
+set wd_sig [gtkwave::getTotalNumTraces]
 gtkwave::addSignalsFromList [list {tb.top.reset_inst/ethernet_reset}]
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reset_inst/ethernet_reset}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Data_Format/Hex
 gtkwave::/Edit/UnHighlight_All
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reset_inst/ethernet_reset}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Color_Format/Red
 gtkwave::/Edit/UnHighlight_All
+if {[gtkwave::getTotalNumTraces] > $wd_start_0} {
 gtkwave::/Edit/UnHighlight_All
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reset_inst/pcie_rstn}
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reset_inst/ethernet_reset}
+for {set wd_i $wd_start_0} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Create_Group {reset_group}
 gtkwave::/Edit/UnHighlight_All
+}
 
+set wd_start_0 [gtkwave::getTotalNumTraces]
+set wd_sig [gtkwave::getTotalNumTraces]
 gtkwave::addSignalsFromList [list {tb.top.reg_inst.register[0]}]
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[0\\]}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Color_Format/Yellow
 gtkwave::/Edit/UnHighlight_All
+if {[gtkwave::getTotalNumTraces] > $wd_start_0} {
 gtkwave::/Edit/UnHighlight_All
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[0\\]}
+for {set wd_i $wd_start_0} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Create_Group {reg 0}
 gtkwave::/Edit/UnHighlight_All
+}
 
+set wd_start_0 [gtkwave::getTotalNumTraces]
+set wd_sig [gtkwave::getTotalNumTraces]
 gtkwave::addSignalsFromList [list {tb.top.reg_inst.register[1]}]
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[1\\]}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Color_Format/Yellow
 gtkwave::/Edit/UnHighlight_All
+if {[gtkwave::getTotalNumTraces] > $wd_start_0} {
 gtkwave::/Edit/UnHighlight_All
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[1\\]}
+for {set wd_i $wd_start_0} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Create_Group {reg 1}
 gtkwave::/Edit/UnHighlight_All
+}
 
+set wd_start_0 [gtkwave::getTotalNumTraces]
+set wd_sig [gtkwave::getTotalNumTraces]
 gtkwave::addSignalsFromList [list {tb.top.reg_inst.register[2]}]
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[2\\]}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Color_Format/Yellow
 gtkwave::/Edit/UnHighlight_All
+if {[gtkwave::getTotalNumTraces] > $wd_start_0} {
 gtkwave::/Edit/UnHighlight_All
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[2\\]}
+for {set wd_i $wd_start_0} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Create_Group {reg 2}
 gtkwave::/Edit/UnHighlight_All
+}
 
+set wd_start_0 [gtkwave::getTotalNumTraces]
+set wd_sig [gtkwave::getTotalNumTraces]
 gtkwave::addSignalsFromList [list {tb.top.reg_inst.register[3]}]
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[3\\]}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Color_Format/Yellow
 gtkwave::/Edit/UnHighlight_All
+if {[gtkwave::getTotalNumTraces] > $wd_start_0} {
 gtkwave::/Edit/UnHighlight_All
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[3\\]}
+for {set wd_i $wd_start_0} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Create_Group {reg 3}
 gtkwave::/Edit/UnHighlight_All
+}
 
+set wd_start_0 [gtkwave::getTotalNumTraces]
+set wd_sig [gtkwave::getTotalNumTraces]
 gtkwave::addSignalsFromList [list {tb.top.reg_inst.register[4]}]
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[4\\]}
+gtkwave::/Edit/UnHighlight_All
+for {set wd_i $wd_sig} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Color_Format/Yellow
 gtkwave::/Edit/UnHighlight_All
+if {[gtkwave::getTotalNumTraces] > $wd_start_0} {
 gtkwave::/Edit/UnHighlight_All
-gtkwave::/Edit/Highlight_Regexp {^tb\\.top\\.reg_inst\\.register\\[4\\]}
+for {set wd_i $wd_start_0} {$wd_i < [gtkwave::getTotalNumTraces]} {incr wd_i} {
+    gtkwave::setTraceHighlightFromIndex $wd_i 1
+}
 gtkwave::/Edit/Create_Group {reg 4}
 gtkwave::/Edit/UnHighlight_All
+}
 
+gtkwave::/Edit/UnHighlight_All
 gtkwave::/Edit/Set_Trace_Max_Hier 1
 """
 

--- a/tests/test_tcl_quoting.py
+++ b/tests/test_tcl_quoting.py
@@ -1,0 +1,145 @@
+"""Tests for the quoting of user text in the generated TCL.
+
+Group titles, divider text and signal paths come straight from the user's
+`.wave.py` and are interpolated into the script. They used to go in raw
+inside `{...}`, which holds until a name carries a brace of its own -- and
+since groups are now built inside an `if {...}` block, a stray brace no
+longer breaks one command, it closes the block early and takes the group
+creation with it, silently.
+"""
+
+import shutil
+import subprocess
+import unittest
+
+from wavedisp.ast import Block, Disp, Divider, Group
+from wavedisp.targets.gtkwave import GTKWaveTarget, tcl_word
+
+# Names a braced word cannot carry: an unbalanced brace ends it early, and
+# a backslash can escape the closing one.
+NEEDS_ESCAPING = ["bad } name", "{unclosed", "closed}{reopened", "back\\slash", "trailing\\"]
+
+# Names that must keep their braces, so the generated script stays
+# readable. Braces of their own are fine as long as they balance, and a
+# quote or a `$` is inert inside a braced word.
+BRACE_SAFE = [
+    "dut",
+    "tb.top.sig",
+    "dut (ADRREG=0, OUTREGA=0)",
+    "side A -- strided",
+    "a$b",
+    "array{0}",
+    'quote"here',
+]
+
+ALL_NAMES = NEEDS_ESCAPING + BRACE_SAFE
+
+
+def generate(tree):
+    return GTKWaveTarget(tree).genstr
+
+
+class TestTclWord(unittest.TestCase):
+    def test_safe_names_stay_braced(self):
+        for name in BRACE_SAFE:
+            self.assertEqual(tcl_word(name), "{" + name + "}", name)
+
+    def test_unsafe_names_are_escaped_instead(self):
+        for name in NEEDS_ESCAPING:
+            self.assertFalse(tcl_word(name).startswith("{"), name)
+
+    def test_no_name_leaks_an_unbalanced_brace(self):
+        """What broke the `if` block: a brace counted by the enclosing one."""
+        for name in ALL_NAMES:
+            depth = 0
+            escaped = False
+            for char in tcl_word(name):
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+            self.assertEqual(depth, 0, name)
+
+
+class TestGeneratedScriptQuoting(unittest.TestCase):
+    def test_group_body_is_not_truncated_by_a_brace_in_the_title(self):
+        """The regression that motivated this: `}` used to close the `if`."""
+        blk = Block()
+        grp = blk.add(Group("bad } name"))
+        grp.add(Disp("sig"))
+        tail = generate(blk).partition("Create_Group")[2]
+        self.assertIn("UnHighlight_All", tail)
+        self.assertIn("\n}\n", tail)
+
+
+@unittest.skipUnless(shutil.which("tclsh"), "tclsh not installed")
+class TestTclParses(unittest.TestCase):
+    """Run the generated script under a real TCL interpreter.
+
+    Structural assertions can only say the text looks right; only an
+    interpreter says the words arrive as the user wrote them, as one
+    argument each.
+    """
+
+    STUBS = """
+namespace eval gtkwave {
+    variable count 0
+    proc getTotalNumTraces {} { variable count; return $count }
+    proc setTraceHighlightFromIndex {i on} {}
+    proc addSignalsFromList {names} {
+        variable count
+        foreach n $names { puts "CALL signal $n"; incr count }
+    }
+    proc /Edit/Set_Trace_Max_Hier {n} {}
+    proc /Edit/UnHighlight_All {} {}
+    proc /Edit/Insert_Comment {text} {
+        variable count
+        puts "CALL comment $text"; incr count
+    }
+    proc /Edit/Create_Group {name} { puts "CALL group $name" }
+}
+"""
+
+    def run_script(self, script):
+        """Return the calls the interpreter made, as (kind, argument) pairs.
+
+        A stub taking exactly one argument is the assertion that matters:
+        a name split into several words raises "called with too many
+        arguments". tclsh reports that on stderr but still exits 0 when it
+        happens inside a block, so the exit status alone proves nothing.
+        """
+        proc = subprocess.run(
+            ["tclsh"],
+            input=self.STUBS + script,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stderr, "", proc.stderr)
+        return [line[len("CALL ") :].split(" ", 1) for line in proc.stdout.splitlines() if line.startswith("CALL ")]
+
+    def test_every_name_survives_the_interpreter_intact(self):
+        for name in ALL_NAMES:
+            blk = Block()
+            grp = blk.add(Group(name))
+            grp.add(Divider(name))
+            grp.add(Disp("sig"))
+            self.assertEqual(
+                self.run_script(generate(blk)),
+                [["comment", name], ["signal", ".sig"], ["group", name]],
+                repr(name),
+            )
+
+    def test_a_hostile_signal_path_is_added_as_one_signal(self):
+        blk = Block()
+        blk.add(Disp("sig{0}"))
+        self.assertEqual(self.run_script(generate(blk)), [["signal", ".sig{0}"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wavedisp/targets/gtkwave.py
+++ b/wavedisp/targets/gtkwave.py
@@ -27,6 +27,37 @@ from .x11colors import X11_COLORS
 LOGGER = logging.getLogger("wavegen")
 
 
+def tcl_word(text):
+    """Quote ``text`` so gtkwave receives it as one TCL word.
+
+    Names reach the script straight from the user's ``.wave.py``: group
+    titles, divider text, signal paths. Interpolating them raw into
+    ``{...}`` works until one of them carries a brace, and then the
+    braced word ends early -- which now truncates the enclosing ``if``
+    block and silently drops the group creation with it, not just the one
+    command.
+
+    Braces are kept when they are safe, since that is the ordinary case
+    and the generated script is meant to be readable. A string is safe
+    when its braces are balanced and it holds no backslash, a backslash
+    being able to escape the closing brace. Anything else is emitted as a
+    backslash-escaped bare word.
+    """
+    depth = 0
+    for char in text:
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth < 0:
+                break
+    else:
+        if depth == 0 and "\\" not in text:
+            return "{" + text + "}"
+
+    return "".join("\\" + c if c in ' \t\n\\$[]{}";' else c for c in text)
+
+
 def highlight_added(var):
     """Highlight every trace added since ``var`` was captured.
 
@@ -147,7 +178,7 @@ class GTKWaveTarget(Visitor):
         self.genstr += f"if {{[gtkwave::getTotalNumTraces] > ${var}}} {{\n"
         self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
         self.genstr += highlight_added(var)
-        self.genstr += f"gtkwave::/Edit/Create_Group {{{tree.value[0]}}}\n"
+        self.genstr += f"gtkwave::/Edit/Create_Group {tcl_word(tree.value[0])}\n"
         self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
         self.genstr += "}\n"
 
@@ -157,7 +188,7 @@ class GTKWaveTarget(Visitor):
         :param tree: AST tree instance.
         """
 
-        self.genstr += f"gtkwave::/Edit/Insert_Comment {{{tree.value[0]}}}\n"
+        self.genstr += f"gtkwave::/Edit/Insert_Comment {tcl_word(tree.value[0])}\n"
 
         super().process_divider(tree)
 
@@ -178,7 +209,7 @@ class GTKWaveTarget(Visitor):
             tagged = bool(tree.properties.get("radix") or tree.properties.get("color"))
             if tagged:
                 self.genstr += "set wd_sig [gtkwave::getTotalNumTraces]\n"
-            self.genstr += f"gtkwave::addSignalsFromList [list {{{fullname}}}]\n"
+            self.genstr += f"gtkwave::addSignalsFromList [list {tcl_word(fullname)}]\n"
 
             if "radix" in tree.properties:
                 radix = tree.properties["radix"]

--- a/wavedisp/targets/gtkwave.py
+++ b/wavedisp/targets/gtkwave.py
@@ -20,12 +20,34 @@
 """Generator for the GTKWave viewer."""
 
 import logging
-import re
 
 from ..visitor import Visitor
 from .x11colors import X11_COLORS
 
 LOGGER = logging.getLogger("wavegen")
+
+
+def highlight_added(var):
+    """Highlight every trace added since ``var`` was captured.
+
+    gtkwave has no command to highlight a trace by literal name, only by
+    regex, and a regex cannot name a trace reliably: it matches against
+    the *displayed* name, where a one-bit signal appears as ``name[0]``,
+    a bus as ``name[hi:lo]`` and an array element as ``name[0][7:0]``.
+    Anchoring to tell those apart is guesswork, and ``re.escape`` emits
+    Python escapes that glibc reads as POSIX *basic* operators, so any
+    name carrying ``(``, ``|`` or ``+`` matches nothing at all.
+
+    Positions have none of those problems. The generated script records
+    the trace count before adding, then highlights every row that
+    appeared -- whatever it is called, and including the comment rows a
+    name match can never reach.
+    """
+    return (
+        f"for {{set wd_i ${var}}} {{$wd_i < [gtkwave::getTotalNumTraces]}} {{incr wd_i}} {{\n"
+        f"    gtkwave::setTraceHighlightFromIndex $wd_i 1\n"
+        f"}}\n"
+    )
 
 
 class GTKWaveTarget(Visitor):
@@ -89,9 +111,8 @@ class GTKWaveTarget(Visitor):
         return keys[index]
 
     def __init__(self, tree):
-        # Stack of list of signal to group. When the stack is empty
-        # Disp and Divider must not push information.
-        self.stack = []
+        # Group nesting depth, used to name one TCL variable per level.
+        self.depth = 0
 
         # Header
         self.genstr = "# Wavedisp generated gtkwave file\n"
@@ -101,7 +122,10 @@ class GTKWaveTarget(Visitor):
         self.visit(tree)
 
         # Footer
-        self.genstr += "\ngtkwave::/Edit/Set_Trace_Max_Hier 1\n"  # Restore signal length.
+        # Leave nothing highlighted: the viewer would otherwise open with
+        # the whole last group selected.
+        self.genstr += "\ngtkwave::/Edit/UnHighlight_All\n"
+        self.genstr += "gtkwave::/Edit/Set_Trace_Max_Hier 1\n"  # Restore signal length.
 
     def process_group(self, tree):
         """Method to process an ast.Group node.
@@ -109,28 +133,23 @@ class GTKWaveTarget(Visitor):
         :param tree: AST tree instance.
         """
 
-        # Push a new list in the stack
-        self.stack.append([])
-        self.genstr += "\n"
+        # One variable per nesting depth: an inner group is created
+        # during the outer one's span, and the outer span is measured
+        # after it, so the rows the inner group added are included.
+        var = f"wd_start_{self.depth}"
+        self.depth += 1
+        self.genstr += f"\nset {var} [gtkwave::getTotalNumTraces]\n"
 
         # Recurse
         super().process_group(tree)
 
-        # Create the group by analyzing the stack
-        if self.stack[-1]:
-            self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
-            for name in self.stack[-1]:
-                name_esc = re.escape(name)
-                self.genstr += f"gtkwave::/Edit/Highlight_Regexp {{^{name_esc}}}\n"
-            self.genstr += f"gtkwave::/Edit/Create_Group {{{tree.value[0]}}}\n"
-            self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
-
-        # The current list in the stack is processed, we can remove it.
-        self.stack.pop()
-
-        # Append the group name in the stack if not empty.
-        if self.stack:
-            self.stack[-1].append(tree.value[0])
+        self.depth -= 1
+        self.genstr += f"if {{[gtkwave::getTotalNumTraces] > ${var}}} {{\n"
+        self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
+        self.genstr += highlight_added(var)
+        self.genstr += f"gtkwave::/Edit/Create_Group {{{tree.value[0]}}}\n"
+        self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
+        self.genstr += "}\n"
 
     def process_divider(self, tree):
         """Method to process an ast.Divider node.
@@ -151,11 +170,14 @@ class GTKWaveTarget(Visitor):
         for value in tree.value:
             hierarchy = tree.hierarchy.split("/")
             fullname = ".".join(hierarchy[1:]) + "." + value
-            fullname_esc = re.escape(fullname)
 
-            if self.stack:
-                self.stack[-1].append(fullname)
-
+            # Properties apply to whatever this add produced -- nothing at
+            # all if the signal is absent from the dump, which is why the
+            # count is compared rather than assumed to grow by one. Only
+            # worth recording when there is a property to apply.
+            tagged = bool(tree.properties.get("radix") or tree.properties.get("color"))
+            if tagged:
+                self.genstr += "set wd_sig [gtkwave::getTotalNumTraces]\n"
             self.genstr += f"gtkwave::addSignalsFromList [list {{{fullname}}}]\n"
 
             if "radix" in tree.properties:
@@ -163,7 +185,8 @@ class GTKWaveTarget(Visitor):
                 if radix != "":
                     try:
                         radix_conv = self.RadixDict[radix]
-                        self.genstr += f"gtkwave::/Edit/Highlight_Regexp {{^{fullname_esc}}}\n"
+                        self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
+                        self.genstr += highlight_added("wd_sig")
                         self.genstr += f"gtkwave::/Edit/Data_Format/{radix_conv}\n"
                         self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
                     except KeyError:
@@ -177,7 +200,8 @@ class GTKWaveTarget(Visitor):
                         found_color = self.nearest_color(color)
 
                         # Write the result
-                        self.genstr += f"gtkwave::/Edit/Highlight_Regexp {{^{fullname_esc}}}\n"
+                        self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
+                        self.genstr += highlight_added("wd_sig")
                         self.genstr += f"gtkwave::/Edit/Color_Format/{found_color}\n"
                         self.genstr += "gtkwave::/Edit/UnHighlight_All\n"
                     except KeyError:


### PR DESCRIPTION
Groups and trace properties were selected with `Highlight_Regexp` on the **displayed** trace name. That can never be made reliable, because no shape identifies a signal: gtkwave shows a one-bit signal as `name[0]`, a bus as `name[hi:lo]`, an array element as `name[0][7:0]`. Every anchoring choice trades one wrong answer for another — and a comment row has no signal name at all, so a divider could never be grouped.

Measured on a real save file before the change: the seven groups of a testbench held **every one of their signals and not one of their 13 labels**.

## What it does

The target records `getTotalNumTraces` before a group’s contents and highlights every row that appeared, whatever it is called. Positions do not care whether a row is a signal, a bus or a comment.

- The span is read **at run time**, so nothing depends on assumptions about how many rows `Create_Group` inserts.
- Nested groups fall out of it: one variable per depth, the outer span measured after the inner group was created.
- Radix and colour move to positions too, which removes name matching from the target entirely. The count is compared before and after the add rather than assumed to grow by one, so a signal absent from the dump no longer applies its radix to whatever sits above it.
- A final `UnHighlight_All` is emitted — the viewer used to open with the whole last group selected.

## Result, measured on the same wave files

| | before | after |
|---|---|---|
| labels inside a group | 0 / 13 | **11 / 13** |
| regexes emitted | 98 | **0** |

The two remaining labels belong to the testbench and to no group, which is correct. Each group holds exactly what its `.wave.py` declares: 38 signals + 5 labels for a DUT opened with its internals, 20 + 3 for the port-only variants, 5 + 0 for instances declaring no divider.

## History

The first three commits tried to fix the regex rather than replace it, and two of them were wrong in opposite directions — unanchored took `enb` and `ena_bank` along with `en`; requiring a range in the bracket group dropped all 13 one-bit signals out of their group. Both were found by inspecting a GTKWave `.sav` produced from the generated script, not by reasoning. They are kept in the history because the dead ends explain the final design.

An escaping problem disappears with them: `re.escape` emits Python escapes, and gtkwave matches with glibc `regcomp`, which defaults to POSIX **basic** syntax where `\(`, `\|` and `\+` are operators. Any name containing those silently matched nothing.

## Tests

`tests/test_group_spans.py` pins the structure — a divider inside its group’s span, distinct variables per nesting level, the guard against creating an empty group, a property scoped to what its add produced, and no `Highlight_Regexp` anywhere. What gtkwave then does with the script can only be checked in the viewer, which is how the earlier attempts were found wrong.