### PR TITLE
feat(surfer): add a target for the Surfer waveform viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage.xml
 .pytest_cache/
 test_*.dot
 test_*.tcl
+test_*.sucl
 tests.xml
 
 # Translations

--- a/README.md
+++ b/README.md
@@ -1,47 +1,408 @@
 # Wavedisp
 
-## Introduction
-Wavedisp is a package to help you in displaying waveforms for different HDL simulators or VCD viewers in a portable
-way. It generates waveform files for GTKWave, Modelsim and RivierPro by genereting tcl scripts loaded by the HDL viewer
-from a unique representation described in python. Surfer is also supported, through the command file it replays after
-loading a waveform:
+Describe a waveform layout once, in Python, and generate the save file every viewer wants.
+
+A testbench worth debugging twice deserves a signal list worth keeping. Every viewer stores one, but each in its own
+format — GTKWave's TCL, Modelsim's `do` script, Surfer's command file — none of which is pleasant to write by hand, all
+of which drift the moment a port is renamed. Wavedisp keeps the description in one Python file next to the RTL, under
+version control, and emits the rest:
 
 ```sh
-wavedisp -t surfer -o my_tb.sucl my_tb.wave.py
-surfer my_tb.vcd --command-file my_tb.sucl
+wavedisp -t gtkwave    -o counter_tb.gtkwave.tcl    counter_tb.wave.py
+wavedisp -t modelsim   -o counter_tb.modelsim.tcl   counter_tb.wave.py
+wavedisp -t rivierapro -o counter_tb.rivierapro.tcl counter_tb.wave.py
+wavedisp -t surfer     -o counter_tb.sucl           counter_tb.wave.py
 ```
 
-Surfer has no scripting language, so that file is a flat list of commands whose effect depends on the row Surfer has
-focused. The target predicts every row index rather than reading it back, because a command file cannot read anything
-back. Two consequences are worth knowing:
+Because a description is a Python program, it can take parameters, loop over generate blocks, and be included by
+another description — the same way the RTL it follows is written.
 
-* a signal that is missing from the dump adds no row, and every command after it lands one row off. Surfer logs the
-  failed `variable_add`, and its `dump_tree` command prints the tree that was actually built;
-* each line of a command file is trimmed, truncated at the first `#`, then split on `;`, all before anything is
-  parsed, and none of it can be quoted or escaped, so none of those three can appear anywhere. In a *name* they are replaced by `_` and reported —
-  a recognisable wrong name beats a truncated one. In a *signal path* the signal is dropped instead and reported:
-  a substituted path names something the dump does not contain, so Surfer would add no row where this file counted
-  one, and every later index would be off.
+## Installation
 
-The `height` property keeps its meaning across targets. Modelsim and RivieraPro take a pixel count; Surfer has no pixel
-form, only a factor on its configured line height, and draws a row `waveforms_line_height * factor` tall. The target
-divides by that line height, so `height=32` gives the same 32-pixel row everywhere. If your Surfer configuration changes
+```sh
+pip install wavedisp
+```
+
+Requires Python 3.10 or later, with no runtime dependencies. For a checkout:
+
+```sh
+git clone https://github.com/cclienti/wavedisp.git
+cd wavedisp
+pip install -e .
+```
+
+## Quick start
+
+A description is a Python module with a function — `generator` by default — returning a tree of nodes:
+
+```python
+# counter_tb.wave.py
+from wavedisp.ast import Disp, Divider, Hierarchy
+
+
+def generator():
+    testbench = Hierarchy('counter_tb')
+    testbench.add(Disp(['clk', 'rst_n']))
+
+    dut = testbench.add(Hierarchy('dut'))
+    dut.add(Divider('control'))
+    dut.add(Disp(['enable', 'load']))
+    dut.add(Disp('count', radix='unsigned'))
+
+    return testbench
+```
+
+Generate a save file and open it:
+
+```sh
+wavedisp -t gtkwave -o counter_tb.gtkwave.tcl counter_tb.wave.py
+gtkwave -S counter_tb.gtkwave.tcl counter_tb.vcd
+```
+
+Signal names are written relative to the enclosing `Hierarchy`, so `count` above resolves to `counter_tb.dut.count`.
+
+## Writing a description
+
+### Signals
+
+`Disp` adds one row per signal. It takes a name or a list of them:
+
+```python
+dut.add(Disp('count'))
+dut.add(Disp(['enable', 'load', 'done']))
+```
+
+A name may carry a path of its own, which saves declaring a `Hierarchy` for a single signal:
+
+```python
+dut.add(Disp('fifo_inst/write_ptr'))
+```
+
+### Scopes
+
+`Hierarchy` sets the instance path its children are resolved against. Nesting them concatenates:
+
+```python
+testbench = Hierarchy('counter_tb')       # counter_tb
+dut = testbench.add(Hierarchy('dut'))     # counter_tb.dut
+fifo = dut.add(Hierarchy('fifo_inst'))    # counter_tb.dut.fifo_inst
+fifo.add(Disp('full'))                    # counter_tb.dut.fifo_inst.full
+```
+
+`add` returns the node it was given, which is what makes that read top-down.
+
+Generate blocks are addressed by their elaborated path, exactly as the simulator names them:
+
+```python
+for index in range(4):
+    lane = dut.add(Hierarchy(f'gen_lane[{index}].lane_inst'))
+    lane.add(Disp('valid'))
+```
+
+### Groups
+
+`Group` collects its contents into one foldable row:
+
+```python
+group = dut.add(Group('write port'))
+group.add(Disp(['wr_en', 'wr_addr', 'wr_data']))
+```
+
+Groups nest, and they are what keeps a large default view usable — see
+[Keeping the default view small](#keeping-the-default-view-small).
+
+### Dividers
+
+`Divider` inserts a labelled separator:
+
+```python
+dut.add(Divider('handshake'))
+```
+
+### Blocks
+
+`Block` groups nodes without producing a row of its own. It exists to apply a property to several nodes at once, and to
+give a description a root when it has no natural one:
+
+```python
+block = Block(radix='hexadecimal')     # applies to everything inside
+block.add(Disp(['addr', 'data']))
+```
+
+### Display properties
+
+Three properties are accepted by every node, as keyword arguments:
+
+| Property | Values | Meaning |
+| --- | --- | --- |
+| `radix` | `binary`, `hexadecimal`, `signed`, `unsigned`, `octal`, `string`, `symbolic` | how the value is rendered |
+| `color` | any [X11 colour name](https://en.wikipedia.org/wiki/X11_color_names) — `red`, `SteelBlue`, … | trace colour |
+| `height` | a pixel count, e.g. `32` | row height |
+
+```python
+dut.add(Disp('count', radix='unsigned'))
+dut.add(Disp('state', radix='symbolic', color='SteelBlue'))
+dut.add(Disp('sample', radix='signed', height=32))
+```
+
+A property set on a node applies to every descendant that does not set its own, so the common case is written once:
+
+```python
+regs = dut.add(Group('registers', radix='hexadecimal'))
+regs.add(Disp(['r0', 'r1', 'r2']))              # hexadecimal, inherited
+regs.add(Disp('flags', radix='binary'))         # binary, its own choice wins
+```
+
+Not every viewer honours every property — see [Targets](#targets).
+
+### Reusing a description
+
+`include` pulls in another description and attaches it under the current node. The usual arrangement is one file per
+module, describing that module's own signals with no idea where it will be instantiated, plus one per testbench that
+places them:
+
+```python
+# fifo.wave.py — the module's own signals, relative to itself
+from wavedisp.ast import Block, Disp, Divider
+
+
+def generator():
+    block = Block()
+    block.add(Disp(['wr_en', 'rd_en', 'full', 'empty']))
+    block.add(Divider('internals'))
+    block.add(Disp(['write_ptr', 'read_ptr'], radix='unsigned'))
+    return block
+```
+
+```python
+# fifo_tb.wave.py — where those signals live in this testbench
+from wavedisp.ast import Disp, Hierarchy
+
+
+def generator():
+    testbench = Hierarchy('fifo_tb')
+    testbench.add(Disp(['clk', 'rst_n']))
+
+    dut = testbench.add(Hierarchy('dut'))
+    dut.include('fifo.wave.py')
+
+    return testbench
+```
+
+A relative include resolves **against the directory of the file containing it**, not the working directory, so a
+description can be included from anywhere:
+
+```python
+lane.include('../../fifo/project/fifo.wave.py')
+```
+
+`include` returns the included tree, so it can be extended in place:
+
+```python
+tree = dut.include('fifo.wave.py')
+tree.add(Disp('debug_state'))
+```
+
+### Parameterised descriptions
+
+A generator is an ordinary function, so it can take arguments, and callers pass them through `include`:
+
+```python
+# parmem.wave.py
+from wavedisp.ast import Block, Disp, Group, Hierarchy
+
+
+def generator(nb_banks=4, internals=False):
+    block = Block()
+    block.add(Disp(['en', 'addr', 'dout']))
+
+    if internals:
+        for bank in range(nb_banks):
+            group = block.add(Group(f'bank {bank}'))
+            group.add(Hierarchy(f'gen_bank[{bank}].bank_inst')).add(Disp('doa'))
+
+    return block
+```
+
+```python
+dut.include('parmem.wave.py', nb_banks=8, internals=True)
+```
+
+The top-level generator takes its arguments from the command line, as JSON:
+
+```sh
+wavedisp -t gtkwave -a '{"nb_banks": 8, "internals": true}' -o out.tcl parmem_tb.wave.py
+```
+
+Use `-g` when the function is not called `generator`:
+
+```sh
+wavedisp -g post_synth_generator -o out.tcl parmem_tb.wave.py
+```
+
+## Command line
+
+```
+wavedisp [-h] [-o OUTPUT] [-t TARGET] [-g GENERATOR] [-a KWARGS] [-T TARGET_KWARGS] [-v] [-d] input
+```
+
+| Option | Meaning |
+| --- | --- |
+| `input` | the description file |
+| `-o`, `--output` | output filename |
+| `-t`, `--target` | `gtkwave` (default), `modelsim`, `rivierapro`, `surfer`, `dot` |
+| `-g`, `--generator` | name of the generator function (default `generator`) |
+| `-a`, `--kwargs` | JSON object passed to the **generator function** |
+| `-T`, `--target-kwargs` | JSON object passed to the **target** |
+| `-v`, `--verbose` | log every file included and the generator used for it |
+| `-d`, `--debug` | more of the same |
+
+`-a` and `-T` are easy to confuse, and they reach different places: `-a` parameterises *what* is described, `-T` *how*
+it is rendered. An option the selected target does not take is reported and exits non-zero rather than being silently
+ignored.
+
+Anything that goes wrong — an unknown radix, a colour that is not an X11 name, a missing include — is logged with the
+file and line of the node that caused it, and makes wavedisp exit non-zero, so a Makefile stops rather than leaving a
+half-correct file behind.
+
+## Targets
+
+| Viewer | `-t` | Output | Load it with |
+| --- | --- | --- | --- |
+| GTKWave | `gtkwave` | TCL script | `gtkwave -S layout.gtkwave.tcl dump.vcd` |
+| Modelsim / Questa | `modelsim` | TCL script | `vsim -do 'do layout.modelsim.tcl; run -all' tb` |
+| Aldec Riviera-PRO | `rivierapro` | TCL script | `vsim -do 'do layout.rivierapro.tcl; run -all' tb` |
+| Surfer | `surfer` | `.sucl` command file | `surfer dump.vcd --command-file layout.sucl` |
+| Graphviz | `dot` | `.dot` graph | `xdot layout.dot` — renders the tree, for debugging a description |
+
+What each one honours:
+
+| | `radix` | `color` | `height` | groups |
+| --- | --- | --- | --- | --- |
+| GTKWave | all seven | nearest of 7 | ignored | yes |
+| Modelsim | all seven | exact RGB | pixels | yes |
+| Riviera-PRO | see note | exact RGB | pixels | yes |
+| Surfer | all seven | nearest of 8 | converted | yes |
+
+### GTKWave
+
+Colours are reduced to the seven GTKWave supports, by nearest RGB. `height` has no equivalent and is dropped.
+
+### Modelsim and Riviera-PRO
+
+Both take an exact RGB colour and a pixel `height`.
+
+The Riviera-PRO radix mapping looks wrong and predates the current maintainers of this file: a radix is emitted as
+`add wave -radix -hex`, combining the long option with the shorthand value, and `symbolic` maps to nothing at all,
+leaving a `-radix` with no value after it. The behaviour is pinned by the target's reference test, so it has been this
+way for a long time; it has not been re-checked against a real Riviera-PRO installation. If you use that target, check
+what it emits before trusting the `radix` property.
+
+### Surfer
+
+Surfer has no scripting language: a command file is a flat list of the commands its prompt accepts, and each one acts
+on the row Surfer has *focused*. The target therefore tracks every row index itself and emits the focus commands to
+match, because a command file cannot read anything back. Three consequences are worth knowing.
+
+**A signal missing from the dump shifts everything after it.** It adds no row, while the file counted one, so later
+commands land one row off. Surfer logs the failed `variable_add`, and its `dump_tree` command prints the tree it
+actually built. Nothing in the command language can detect this from the inside, so a description that has drifted from
+the RTL fails worse here than elsewhere.
+
+**Three characters cannot appear anywhere.** Each line is trimmed, truncated at the first `#`, then split on `;`, all
+before any command is parsed, and none of it can be quoted or escaped. In a *name* they are replaced by `_` and
+reported. In a *signal path* the signal is dropped and reported instead — a substituted path names something the dump
+does not contain, which would shift every later row.
+
+**Colours are theme names, not values.** They are matched against the eight of Surfer's default theme, by name first
+and nearest RGB otherwise. The `ibm`, `petroff-*` and `*-high-contrast` themes define different names, and a name a
+theme does not define leaves the row at its default colour.
+
+`height` keeps its meaning across targets. Modelsim and Riviera-PRO take a pixel count; Surfer has no pixel form, only
+a factor on its configured line height, and draws a row `waveforms_line_height * factor` tall. The target divides by
+that line height, so `height=32` is a 32-pixel row everywhere. If your Surfer configuration changes
 `layout.waveforms_line_height` from its default of 16, say so:
 
 ```sh
-wavedisp -t surfer -T '{"line_height": 20}' -o my_tb.sucl my_tb.wave.py
+wavedisp -t surfer -T '{"line_height": 20}' -o layout.sucl tb.wave.py
 ```
 
-`-T`/`--target-kwargs` is to the target what `-a`/`--kwargs` is to the generator function: `-a` parameterises *what* is
-described, `-T` *how* it is rendered. An option the selected target does not take is reported and exits non-zero rather
-than being silently ignored.
+## Recipes
 
-Group and divider names are not otherwise restricted: Surfer only accepts a single bare word there, so the target adds
-the item under a reduced name and immediately renames it to the real one.
+### Keeping the default view small
+
+GTKWave slows to a crawl once a few hundred rows are displayed, which is easier to reach than it sounds: a testbench
+with several instances, each pulling in its sub-hierarchies, runs to several hundred signals without anyone intending
+it. Show ports by default and put the detail behind a keyword the caller opts into:
+
+```python
+def generator(internals=False):
+    block = Block()
+    block.add(Disp(['en', 'wen', 'addr', 'dout']))     # always
+
+    if internals:
+        block.add(Divider('internals'))
+        block.add(Disp(['state', 'next_state']))
+
+    return block
+```
+
+```python
+dut.include('parmem.wave.py', internals=True)    # this instance only
+other.include('parmem.wave.py')                  # ports only
+```
+
+An instance that needs two signals is better served by naming them than by including a whole module description:
+
+```python
+other.add(Disp(['dout', 'freeze']))
+```
+
+### Driving it from a Makefile
+
+```makefile
+%.gtkwave.tcl: %.wave.py
+	wavedisp -t gtkwave -o $@ $<
+
+%.sucl: %.wave.py
+	wavedisp -t surfer -o $@ $<
+
+trace: $(TB).vcd $(TB).gtkwave.tcl
+	gtkwave -S $(TB).gtkwave.tcl $(TB).vcd
+```
+
+Generated save files are build artefacts: keep the `.wave.py` in version control and leave the rest out.
+
+### Checking a description
+
+Nothing generates a description from the RTL and nothing checks it against a dump, so a renamed port leaves a signal
+silently absent. The `dot` target renders the tree wavedisp built, which is the quickest way to see what a
+parameterised description actually produced:
+
+```sh
+wavedisp -t dot -o layout.dot tb.wave.py && xdot layout.dot
+```
+
+Running with `-v` lists every file included and the generator used for it.
+
+## Development
+
+```sh
+git clone https://github.com/cclienti/wavedisp.git
+cd wavedisp
+uv run --group dev pytest
+uv run --group dev ruff check wavedisp tests
+uv run --group dev ruff format --check wavedisp tests
+```
+
+A new target is a `Visitor` subclass in `wavedisp/targets/`, implementing `process_group`, `process_divider` and
+`process_disp`, exposing the generated text as `genstr`, and registered in the `TARGETS` dictionary in
+`wavedisp/cli.py`. Constructor keyword arguments become `-T` options automatically, checked against the target's
+signature.
 
 ## License
-Wavedisp is distributed under the GPLv3, the complete license description can be found
+
+Wavedisp is distributed under the GPLv3, whose complete text can be found
 [here](http://www.gnu.org/licenses/gpl-3.0.html).
 
-## General information
-An example of use is available [here](https://wavecruncher.net/wavedisp). Of course, contribution are welcomed.
+Contributions are welcome. An example of use is available [here](https://wavecruncher.net/wavedisp).

--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@ back. Two consequences are worth knowing:
 
 The `height` property keeps its meaning across targets. Modelsim and RivieraPro take a pixel count; Surfer has no pixel
 form, only a factor on its configured line height, and draws a row `waveforms_line_height * factor` tall. The target
-divides by that line height, so `height=32` gives the same 32-pixel row everywhere. Pass `--surfer-line-height` if your
-Surfer configuration changes `layout.waveforms_line_height` from its default of 16.
+divides by that line height, so `height=32` gives the same 32-pixel row everywhere. If your Surfer configuration changes
+`layout.waveforms_line_height` from its default of 16, say so:
+
+```sh
+wavedisp -t surfer -T '{"line_height": 20}' -o my_tb.sucl my_tb.wave.py
+```
+
+`-T`/`--target-kwargs` is to the target what `-a`/`--kwargs` is to the generator function: `-a` parameterises *what* is
+described, `-T` *how* it is rendered. An option the selected target does not take is reported and exits non-zero rather
+than being silently ignored.
 
 Group and divider names are not otherwise restricted: Surfer only accepts a single bare word there, so the target adds
 the item under a reduced name and immediately renames it to the real one.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ back. Two consequences are worth knowing:
 * a command file is split on `;` and truncated at `#` before anything is parsed, and it has no quoting whatsoever, so
   those two characters cannot appear in a name. They are replaced by `_` and reported.
 
+The `height` property keeps its meaning across targets. Modelsim and RivieraPro take a pixel count; Surfer has no pixel
+form, only a factor on its configured line height, and draws a row `waveforms_line_height * factor` tall. The target
+divides by that line height, so `height=32` gives the same 32-pixel row everywhere. Pass `--surfer-line-height` if your
+Surfer configuration changes `layout.waveforms_line_height` from its default of 16.
+
 Group and divider names are not otherwise restricted: Surfer only accepts a single bare word there, so the target adds
 the item under a reduced name and immediately renames it to the real one.
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ back. Two consequences are worth knowing:
 
 * a signal that is missing from the dump adds no row, and every command after it lands one row off. Surfer logs the
   failed `variable_add`, and its `dump_tree` command prints the tree that was actually built;
-* a command file is split on `;` and truncated at `#` before anything is parsed, and it has no quoting whatsoever, so
-  those two characters cannot appear in a name. They are replaced by `_` and reported.
+* a command file is split into lines, then on `;`, then truncated at `#`, before anything is parsed, and it has no
+  quoting whatsoever, so none of those three can appear anywhere. In a *name* they are replaced by `_` and reported —
+  a recognisable wrong name beats a truncated one. In a *signal path* the signal is dropped instead and reported:
+  a substituted path names something the dump does not contain, so Surfer would add no row where this file counted
+  one, and every later index would be off.
 
 The `height` property keeps its meaning across targets. Modelsim and RivieraPro take a pixel count; Surfer has no pixel
 form, only a factor on its configured line height, and draws a row `waveforms_line_height * factor` tall. The target

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ back. Two consequences are worth knowing:
 
 * a signal that is missing from the dump adds no row, and every command after it lands one row off. Surfer logs the
   failed `variable_add`, and its `dump_tree` command prints the tree that was actually built;
-* a command file is split into lines, then on `;`, then truncated at `#`, before anything is parsed, and it has no
-  quoting whatsoever, so none of those three can appear anywhere. In a *name* they are replaced by `_` and reported —
+* each line of a command file is trimmed, truncated at the first `#`, then split on `;`, all before anything is
+  parsed, and none of it can be quoted or escaped, so none of those three can appear anywhere. In a *name* they are replaced by `_` and reported —
   a recognisable wrong name beats a truncated one. In a *signal path* the signal is dropped instead and reported:
   a substituted path names something the dump does not contain, so Surfer would add no row where this file counted
   one, and every later index would be off.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,25 @@
 ## Introduction
 Wavedisp is a package to help you in displaying waveforms for different HDL simulators or VCD viewers in a portable
 way. It generates waveform files for GTKWave, Modelsim and RivierPro by genereting tcl scripts loaded by the HDL viewer
-from a unique representation described in python.
+from a unique representation described in python. Surfer is also supported, through the command file it replays after
+loading a waveform:
+
+```sh
+wavedisp -t surfer -o my_tb.sucl my_tb.wave.py
+surfer my_tb.vcd --command-file my_tb.sucl
+```
+
+Surfer has no scripting language, so that file is a flat list of commands whose effect depends on the row Surfer has
+focused. The target predicts every row index rather than reading it back, because a command file cannot read anything
+back. Two consequences are worth knowing:
+
+* a signal that is missing from the dump adds no row, and every command after it lands one row off. Surfer logs the
+  failed `variable_add`, and its `dump_tree` command prints the tree that was actually built;
+* a command file is split on `;` and truncated at `#` before anything is parsed, and it has no quoting whatsoever, so
+  those two characters cannot appear in a name. They are replaced by `_` and reported.
+
+Group and divider names are not otherwise restricted: Surfer only accepts a single bare word there, so the target adds
+the item under a reduced name and immediately renames it to the real one.
 
 ## License
 Wavedisp is distributed under the GPLv3, the complete license description can be found

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Describe a waveform layout once, in Python, and generate the save file every viewer wants.
 
 A testbench worth debugging twice deserves a signal list worth keeping. Every viewer stores one, but each in its own
-format — GTKWave's TCL, Modelsim's `do` script, Surfer's command file — none of which is pleasant to write by hand, all
+format — [GTKWave](https://github.com/gtkwave/gtkwave)'s TCL, [Modelsim](https://eda.sw.siemens.com/en-US/ic/questa/simulation/advanced-simulator/)'s `do` script,
+[Surfer](https://gitlab.com/surfer-project/surfer)'s command file — none of which is pleasant to write by hand, all
 of which drift the moment a port is renamed. Wavedisp keeps the description in one Python file next to the RTL, under
 version control, and emits the rest:
 
@@ -269,11 +270,11 @@ half-correct file behind.
 
 | Viewer | `-t` | Output | Load it with |
 | --- | --- | --- | --- |
-| GTKWave | `gtkwave` | TCL script | `gtkwave -S layout.gtkwave.tcl dump.vcd` |
-| Modelsim / Questa | `modelsim` | TCL script | `vsim -do 'do layout.modelsim.tcl; run -all' tb` |
-| Aldec Riviera-PRO | `rivierapro` | TCL script | `vsim -do 'do layout.rivierapro.tcl; run -all' tb` |
-| Surfer | `surfer` | `.sucl` command file | `surfer dump.vcd --command-file layout.sucl` |
-| Graphviz | `dot` | `.dot` graph | `xdot layout.dot` — renders the tree, for debugging a description |
+| [GTKWave](https://github.com/gtkwave/gtkwave) | `gtkwave` | TCL script | `gtkwave -S layout.gtkwave.tcl dump.vcd` |
+| [Modelsim / Questa](https://eda.sw.siemens.com/en-US/ic/questa/simulation/advanced-simulator/) | `modelsim` | TCL script | `vsim -do 'do layout.modelsim.tcl; run -all' tb` |
+| [Aldec Riviera-PRO](https://www.aldec.com/en/products/functional_verification/riviera-pro) | `rivierapro` | TCL script | `vsim -do 'do layout.rivierapro.tcl; run -all' tb` |
+| [Surfer](https://gitlab.com/surfer-project/surfer) | `surfer` | `.sucl` command file | `surfer dump.vcd --command-file layout.sucl` |
+| [Graphviz](https://graphviz.org/) | `dot` | `.dot` graph | `xdot layout.dot` — renders the tree, for debugging a description |
 
 What each one honours:
 
@@ -295,12 +296,13 @@ Both take an exact RGB colour and a pixel `height`.
 The Riviera-PRO radix mapping looks wrong and predates the current maintainers of this file: a radix is emitted as
 `add wave -radix -hex`, combining the long option with the shorthand value, and `symbolic` maps to nothing at all,
 leaving a `-radix` with no value after it. The behaviour is pinned by the target's reference test, so it has been this
-way for a long time; it has not been re-checked against a real Riviera-PRO installation. If you use that target, check
-what it emits before trusting the `radix` property.
+way for a long time; it has not been re-checked against a real Riviera-PRO installation, and cannot be — see
+[Contributing](#contributing). If you use that target, check what it emits before trusting the `radix` property.
 
 ### Surfer
 
-Surfer has no scripting language: a command file is a flat list of the commands its prompt accepts, and each one acts
+Surfer has no scripting language: a command file is a flat list of the [commands its prompt
+accepts](https://docs.surfer-project.org/book/commands/index.html), and each one acts
 on the row Surfer has *focused*. The target therefore tracks every row index itself and emits the focus commands to
 match, because a command file cannot read anything back. Three consequences are worth knowing.
 
@@ -400,9 +402,18 @@ A new target is a `Visitor` subclass in `wavedisp/targets/`, implementing `proce
 `wavedisp/cli.py`. Constructor keyword arguments become `-T` options automatically, checked against the target's
 signature.
 
+## Contributing
+
+Pull requests are welcome, and there is one area where they are needed rather than merely welcome: **the Modelsim and
+Riviera-PRO targets can no longer be tested by the maintainer**, who no longer has access to either tool. They are
+still generated and still covered by their reference tests, but nobody here can load their output into the simulator
+it was written for. If you use one of them, a report that it works — or a patch when it does not — is worth more than
+it looks. The `radix` mapping in the Riviera-PRO target described [above](#modelsim-and-riviera-pro) is exactly the
+kind of thing that has gone unnoticed as a result.
+
+The GTKWave and Surfer targets are checked against the real viewers.
+
 ## License
 
 Wavedisp is distributed under the GPLv3, whose complete text can be found
 [here](http://www.gnu.org/licenses/gpl-3.0.html).
-
-Contributions are welcome. An example of use is available [here](https://wavecruncher.net/wavedisp).

--- a/tests/test_cli_target_kwargs.py
+++ b/tests/test_cli_target_kwargs.py
@@ -29,7 +29,7 @@ import logging
 import unittest
 
 from wavedisp.ast import ASTBase, Block, Disp, Hierarchy
-from wavedisp.cli import TARGETS, check_target_kwargs, make_target
+from wavedisp.cli import TARGETS, check_target_kwargs, decode_kwargs, make_target
 from wavedisp.targets.surfer import SurferTarget
 
 
@@ -122,6 +122,53 @@ class TestMalformedTargetKwargs(unittest.TestCase):
 
     def test_a_value_the_target_rejects_is_reported(self):
         """The target raises ValueError; the CLI turns it into a message."""
+        with self.assertLogs("test:cli", level="ERROR") as logs:
+            self.assertIsNone(make_target("surfer", tree(), self.logger, {"line_height": 0}))
+        self.assertIn("positive", logs.output[0])
+
+
+class TestDecodeKwargs(unittest.TestCase):
+    """Both -a and -T are user-written json and neither may raise."""
+
+    def setUp(self):
+        self.logger = logging.getLogger("test:cli")
+
+    def test_an_object_decodes(self):
+        self.assertEqual(decode_kwargs('{"a": 1}', "-T", self.logger), {"a": 1})
+
+    def test_malformed_json_is_reported(self):
+        with self.assertLogs("test:cli", level="ERROR") as logs:
+            self.assertIsNone(decode_kwargs("{oops", "-T", self.logger))
+        self.assertIn("not valid json", logs.output[0])
+
+    def test_a_non_object_is_reported(self):
+        for text in ("null", "3", '"text"', "[1, 2]"):
+            with self.subTest(text=text), self.assertLogs("test:cli", level="ERROR") as logs:
+                self.assertIsNone(decode_kwargs(text, "-a", self.logger))
+            self.assertIn("must be a json object", logs.output[0])
+
+    def test_a_generation_error_is_not_reported_as_a_bad_option(self):
+        """Only TargetOptionError means "you passed a bad option".
+
+        Every target does its work in __init__, so catching plain
+        ValueError around the construction would blame the user's -T for
+        a fault raised anywhere in the traversal.
+        """
+
+        class Exploding:
+            def __init__(self, tree):
+                raise ValueError("boom from deep inside generation")
+
+        TARGETS["exploding"] = Exploding
+        try:
+            with self.assertRaises(ValueError) as caught:
+                make_target("exploding", tree(), self.logger, {})
+            self.assertIn("deep inside generation", str(caught.exception))
+        finally:
+            del TARGETS["exploding"]
+
+    def test_a_bad_option_value_is_reported(self):
+        """A TargetOptionError, by contrast, is caught and logged."""
         with self.assertLogs("test:cli", level="ERROR") as logs:
             self.assertIsNone(make_target("surfer", tree(), self.logger, {"line_height": 0}))
         self.assertIn("positive", logs.output[0])

--- a/tests/test_cli_target_kwargs.py
+++ b/tests/test_cli_target_kwargs.py
@@ -1,0 +1,85 @@
+#
+# This file is part of wavedisp. See the root README.md for further
+# information.
+#
+# wavedisp is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wavedisp is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with wavedisp.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (C) 2019 Christophe Clienti
+
+"""Test the target arguments coming from --target-kwargs.
+
+Two dictionaries reach two different places, and the names are close
+enough to swap by accident: -a/--kwargs is passed to the *generator
+function* in the input file, -T/--target-kwargs to the *target class*.
+The first describes what to display, the second how to render it.
+"""
+
+import logging
+import unittest
+
+from wavedisp.ast import ASTBase, Block, Disp, Hierarchy
+from wavedisp.cli import TARGETS, make_target
+from wavedisp.targets.surfer import SurferTarget
+
+
+def tree():
+    ASTBase.reset_unique_id()
+    blk = Block()
+    blk.add(Hierarchy("/tb")).add(Disp("sig", height=32))
+    blk.forward()
+    return blk
+
+
+class TestMakeTarget(unittest.TestCase):
+    """Building a target by name, with its own arguments."""
+
+    def setUp(self):
+        self.logger = logging.getLogger("test:cli")
+
+    def test_every_target_builds_with_no_argument(self):
+        for name in TARGETS:
+            with self.subTest(target=name):
+                self.assertIsNotNone(make_target(name, tree(), self.logger))
+
+    def test_an_argument_reaches_the_target(self):
+        target = make_target("surfer", tree(), self.logger, line_height=8.0)
+        self.assertIsInstance(target, SurferTarget)
+        self.assertIn("item_set_height 4\n", target.genstr)
+
+    def test_the_default_is_the_targets_own(self):
+        self.assertIn("item_set_height 2\n", make_target("surfer", tree(), self.logger).genstr)
+
+    def test_an_argument_the_target_does_not_take_is_refused(self):
+        """Rather than a TypeError traceback, or a silent no-effect."""
+        with self.assertLogs("test:cli", level="ERROR") as logs:
+            self.assertIsNone(make_target("gtkwave", tree(), self.logger, line_height=8.0))
+        self.assertIn("line_height", logs.output[0])
+
+    def test_the_message_says_what_the_target_does_take(self):
+        with self.assertLogs("test:cli", level="ERROR") as logs:
+            make_target("surfer", tree(), self.logger, nope=1)
+        self.assertIn("line_height", logs.output[0])
+
+    def test_a_target_with_no_option_says_so(self):
+        with self.assertLogs("test:cli", level="ERROR") as logs:
+            make_target("modelsim", tree(), self.logger, nope=1)
+        self.assertIn("no option", logs.output[0])
+
+    def test_an_unknown_target_is_refused(self):
+        with self.assertLogs("test:cli", level="ERROR"):
+            self.assertIsNone(make_target("nosuchviewer", tree(), self.logger))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_target_kwargs.py
+++ b/tests/test_cli_target_kwargs.py
@@ -29,7 +29,7 @@ import logging
 import unittest
 
 from wavedisp.ast import ASTBase, Block, Disp, Hierarchy
-from wavedisp.cli import TARGETS, make_target
+from wavedisp.cli import TARGETS, check_target_kwargs, make_target
 from wavedisp.targets.surfer import SurferTarget
 
 
@@ -75,6 +75,22 @@ class TestMakeTarget(unittest.TestCase):
         with self.assertLogs("test:cli", level="ERROR") as logs:
             make_target("modelsim", tree(), self.logger, nope=1)
         self.assertIn("no option", logs.output[0])
+
+    def test_every_target_name_refuses_an_option_it_cannot_use(self):
+        """Including "dot", which has no target class to check against.
+
+        dot renders the AST directly and never reaches make_target, so
+        it was the one name that accepted --target-kwargs and wrote the
+        file as though the option had been applied.
+        """
+        for name in [*TARGETS, "dot"]:
+            with self.subTest(target=name), self.assertLogs("test:cli", level="ERROR") as logs:
+                accepted = set() if name == "dot" else None
+                if accepted is None:
+                    self.assertIsNone(make_target(name, tree(), self.logger, nosuchoption=1))
+                else:
+                    self.assertFalse(check_target_kwargs(name, accepted, {"nosuchoption": 1}, self.logger))
+            self.assertIn("nosuchoption", logs.output[0])
 
     def test_an_unknown_target_is_refused(self):
         with self.assertLogs("test:cli", level="ERROR"):

--- a/tests/test_cli_target_kwargs.py
+++ b/tests/test_cli_target_kwargs.py
@@ -50,30 +50,30 @@ class TestMakeTarget(unittest.TestCase):
     def test_every_target_builds_with_no_argument(self):
         for name in TARGETS:
             with self.subTest(target=name):
-                self.assertIsNotNone(make_target(name, tree(), self.logger))
+                self.assertIsNotNone(make_target(name, tree(), self.logger, {}))
 
     def test_an_argument_reaches_the_target(self):
-        target = make_target("surfer", tree(), self.logger, line_height=8.0)
+        target = make_target("surfer", tree(), self.logger, {"line_height": 8.0})
         self.assertIsInstance(target, SurferTarget)
         self.assertIn("item_set_height 4\n", target.genstr)
 
     def test_the_default_is_the_targets_own(self):
-        self.assertIn("item_set_height 2\n", make_target("surfer", tree(), self.logger).genstr)
+        self.assertIn("item_set_height 2\n", make_target("surfer", tree(), self.logger, {}).genstr)
 
     def test_an_argument_the_target_does_not_take_is_refused(self):
         """Rather than a TypeError traceback, or a silent no-effect."""
         with self.assertLogs("test:cli", level="ERROR") as logs:
-            self.assertIsNone(make_target("gtkwave", tree(), self.logger, line_height=8.0))
+            self.assertIsNone(make_target("gtkwave", tree(), self.logger, {"line_height": 8.0}))
         self.assertIn("line_height", logs.output[0])
 
     def test_the_message_says_what_the_target_does_take(self):
         with self.assertLogs("test:cli", level="ERROR") as logs:
-            make_target("surfer", tree(), self.logger, nope=1)
+            make_target("surfer", tree(), self.logger, {"nope": 1})
         self.assertIn("line_height", logs.output[0])
 
     def test_a_target_with_no_option_says_so(self):
         with self.assertLogs("test:cli", level="ERROR") as logs:
-            make_target("modelsim", tree(), self.logger, nope=1)
+            make_target("modelsim", tree(), self.logger, {"nope": 1})
         self.assertIn("no option", logs.output[0])
 
     def test_every_target_name_refuses_an_option_it_cannot_use(self):
@@ -87,14 +87,44 @@ class TestMakeTarget(unittest.TestCase):
             with self.subTest(target=name), self.assertLogs("test:cli", level="ERROR") as logs:
                 accepted = set() if name == "dot" else None
                 if accepted is None:
-                    self.assertIsNone(make_target(name, tree(), self.logger, nosuchoption=1))
+                    self.assertIsNone(make_target(name, tree(), self.logger, {"nosuchoption": 1}))
                 else:
                     self.assertFalse(check_target_kwargs(name, accepted, {"nosuchoption": 1}, self.logger))
             self.assertIn("nosuchoption", logs.output[0])
 
     def test_an_unknown_target_is_refused(self):
         with self.assertLogs("test:cli", level="ERROR"):
-            self.assertIsNone(make_target("nosuchviewer", tree(), self.logger))
+            self.assertIsNone(make_target("nosuchviewer", tree(), self.logger, {}))
+
+
+class TestMalformedTargetKwargs(unittest.TestCase):
+    """--target-kwargs is user JSON: every shape must be reported, not raised."""
+
+    def setUp(self):
+        self.logger = logging.getLogger("test:cli")
+
+    def test_a_json_value_that_is_not_an_object(self):
+        for payload in (None, 3, "text", [1, 2]):
+            with self.subTest(payload=payload), self.assertLogs("test:cli", level="ERROR") as logs:
+                self.assertIsNone(make_target("surfer", tree(), self.logger, payload))
+            self.assertIn("json object", logs.output[0])
+
+    def test_the_dot_path_refuses_it_too(self):
+        with self.assertLogs("test:cli", level="ERROR"):
+            self.assertFalse(check_target_kwargs("dot", set(), None, self.logger))
+
+    def test_a_key_named_like_a_parameter_of_make_target(self):
+        """name/tree/logger must be reported, not bound to the signature."""
+        for key in ("name", "tree", "logger", "kwargs"):
+            with self.subTest(key=key), self.assertLogs("test:cli", level="ERROR") as logs:
+                self.assertIsNone(make_target("surfer", tree(), self.logger, {key: 1}))
+            self.assertIn(key, logs.output[0])
+
+    def test_a_value_the_target_rejects_is_reported(self):
+        """The target raises ValueError; the CLI turns it into a message."""
+        with self.assertLogs("test:cli", level="ERROR") as logs:
+            self.assertIsNone(make_target("surfer", tree(), self.logger, {"line_height": 0}))
+        self.assertIn("positive", logs.output[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_surfer_replay.py
+++ b/tests/test_surfer_replay.py
@@ -1,0 +1,460 @@
+#
+# This file is part of wavedisp. See the root README.md for further
+# information.
+#
+# wavedisp is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wavedisp is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with wavedisp.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (C) 2019 Christophe Clienti
+
+"""Replay a generated Surfer command file against a model of Surfer.
+
+The Surfer target predicts, command by command, where each row will land,
+because a command file cannot read anything back -- there is no
+equivalent of gtkwave's ``getTotalNumTraces``. Nothing in the generated
+file states the tree it is trying to build, so a mistake in that
+arithmetic produces a file that is still valid and quietly wrong.
+
+These tests close that hole the only way it can be closed offline: the
+rules Surfer applies are restated here, the generated file is replayed
+through them, and the resulting tree is compared with the AST it came
+from.
+
+The model follows surfer 0.7.0 (dffac68), ``libsurfer/src/wave_data.rs``
+and ``libsurfer/src/lib.rs``:
+
+* an item is inserted at ``insert_position(focused_item)``, which is
+  *inside* a focused group when it is unfolded and *after* it when it is
+  folded, and at the end of the tree at level 0 when nothing is focused;
+* inserting moves the focus onto the new item, but only if something was
+  focused already;
+* ``group_marked`` groups the focused item alone -- selecting several
+  rows has no command behind it -- and leaves the new group focused;
+* ``item_focus`` addresses a *visible* row, so rows inside a folded group
+  are not counted.
+
+A model is not the program: it can only catch the target disagreeing with
+this reading of Surfer, not the reading being wrong. Running the file is
+what checks the reading.
+"""
+
+import unittest
+
+from wavedisp.ast import ASTBase, Block, Disp, Divider, Group, Hierarchy
+from wavedisp.targets.surfer import SurferTarget
+
+
+class Item:
+    """One row of Surfer's item tree."""
+
+    def __init__(self, kind, name, level):
+        self.kind = kind
+        self.name = name
+        self.level = level
+        self.unfolded = True
+        self.properties = {}
+
+    def __repr__(self):
+        return f"{self.kind}:{self.name}@{self.level}"
+
+
+class SurferModel:
+    """The subset of Surfer's item tree the target drives."""
+
+    def __init__(self):
+        self.items = []
+        self.focused = None  # visible index
+        self.errors = []
+
+    # -- tree queries ----------------------------------------------------
+
+    def hidden(self, index):
+        """Whether the item at ``index`` sits inside a folded ancestor."""
+        level = self.items[index].level
+        for candidate in reversed(self.items[:index]):
+            if candidate.level < level:
+                if not candidate.unfolded:
+                    return True
+                level = candidate.level
+        return False
+
+    def visible(self):
+        """Item indices of the rows Surfer displays, in order."""
+        return [i for i in range(len(self.items)) if not self.hidden(i)]
+
+    def to_item_index(self, vidx):
+        visible = self.visible()
+        return visible[vidx] if 0 <= vidx < len(visible) else None
+
+    def insert_position(self):
+        """Where the next item goes, from the focused row."""
+        if self.focused is None:
+            return len(self.items), 0
+
+        index = self.to_item_index(self.focused)
+        if index is None:
+            return len(self.items), 0
+
+        item = self.items[index]
+        if item.kind == "group":
+            if item.unfolded:
+                return index + 1, item.level + 1
+            following = self.to_item_index(self.focused + 1)
+            return (following if following is not None else len(self.items)), item.level
+        return index + 1, item.level
+
+    # -- commands --------------------------------------------------------
+
+    def _insert(self, item, before, level):
+        item.level = level
+        self.items.insert(before, item)
+        if self.focused is not None:
+            self.focused = self.visible().index(before)
+
+    def variable_add(self, path):
+        before, level = self.insert_position()
+        self._insert(Item("variable", path, level), before, level)
+
+    def divider_add(self, name):
+        before, level = self.insert_position()
+        self._insert(Item("divider", name, level), before, level)
+
+    def group_marked(self, name):
+        if self.focused is None:
+            return  # no selection and no focus: Surfer does nothing
+        before, level = self.insert_position()
+
+        # add_group inserts the group after the focused item, then moves
+        # that item into it. The net effect is the group taking the
+        # item's place with the item as its only child.
+        index = before - 1
+        group = Item("group", name, level)
+        moved = self.items.pop(index)
+        moved.level = level + 1
+        self.items.insert(index, group)
+        self.items.insert(index + 1, moved)
+
+        self.focused = self.visible().index(index)
+
+    def item_focus(self, alpha):
+        index = int("".join(f"{ord(c) - ord('a'):x}" for c in alpha), 16)
+        if index < len(self.items):
+            self.focused = index
+        else:
+            self.errors.append(f"item_focus {alpha} out of range")
+
+    def item_unfocus(self):
+        self.focused = None
+
+    def item_rename(self, name):
+        self._focused_item().name = name
+
+    def item_set_format(self, value):
+        self._focused_item().properties["format"] = value
+
+    def item_set_color(self, value):
+        self._focused_item().properties["color"] = value
+
+    def item_set_height(self, value):
+        self._focused_item().properties["height"] = value
+
+    def group_fold_recursive(self):
+        index = self.to_item_index(self.focused)
+        item = self.items[index]
+        if item.kind != "group":
+            self.errors.append(f"group_fold_recursive on a {item.kind}")
+            return
+        item.unfolded = False
+        for candidate in self.items[index + 1 :]:
+            if candidate.level <= item.level:
+                break
+            candidate.unfolded = False
+
+    def group_unfold_all(self):
+        for item in self.items:
+            item.unfolded = True
+
+    def _focused_item(self):
+        index = self.to_item_index(self.focused)
+        if index is None:
+            self.errors.append("command applied with nothing focused")
+            return Item("none", "", 0)
+        return self.items[index]
+
+    # -- driver ----------------------------------------------------------
+
+    def run(self, script):
+        """Replay a command file, splitting it the way Surfer does."""
+        for line in script.splitlines():
+            line = line.split("#")[0].strip()
+            for command in line.split(";"):
+                command = command.strip()
+                if not command:
+                    continue
+                name, _, argument = command.partition(" ")
+                handler = getattr(self, name, None)
+                if handler is None:
+                    self.errors.append(f"unknown command {name}")
+                    continue
+                handler(argument.strip()) if argument.strip() else handler()
+
+    def render(self):
+        """The tree as nested (name, children) tuples, groups only."""
+        return [(item.level, item.kind, item.name) for item in self.items]
+
+
+def replay(tree):
+    tree.forward()
+    model = SurferModel()
+    model.run(SurferTarget(tree).genstr)
+    return model
+
+
+class TestReplay(unittest.TestCase):
+    """The generated file must build the tree the AST describes."""
+
+    def setUp(self):
+        ASTBase.reset_unique_id()
+        self.maxDiff = None
+
+    def test_flat_list_keeps_order(self):
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(Disp(["a", "b", "c"]))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(model.render(), [(0, "variable", f"tb.{n}") for n in "abc"])
+
+    def test_group_holds_every_row_in_order(self):
+        """The whole reason the target exists: group_marked takes one row."""
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        grp = hier.add(Group("g"))
+        grp.add(Disp(["a", "b", "c"]))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(
+            model.render(),
+            [
+                (0, "group", "g"),
+                (1, "variable", "tb.a"),
+                (1, "variable", "tb.b"),
+                (1, "variable", "tb.c"),
+            ],
+        )
+
+    def test_rows_after_a_group_return_to_the_outer_level(self):
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        grp = hier.add(Group("g"))
+        grp.add(Disp(["a", "b"]))
+        hier.add(Disp("after"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(
+            model.render(),
+            [
+                (0, "group", "g"),
+                (1, "variable", "tb.a"),
+                (1, "variable", "tb.b"),
+                (0, "variable", "tb.after"),
+            ],
+        )
+
+    def test_nested_groups(self):
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        outer = hier.add(Group("outer"))
+        outer.add(Disp("first"))
+        inner = outer.add(Group("inner"))
+        inner.add(Disp(["x", "y"]))
+        outer.add(Disp("last"))
+        hier.add(Disp("after"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(
+            model.render(),
+            [
+                (0, "group", "outer"),
+                (1, "variable", "tb.first"),
+                (1, "group", "inner"),
+                (2, "variable", "tb.x"),
+                (2, "variable", "tb.y"),
+                (1, "variable", "tb.last"),
+                (0, "variable", "tb.after"),
+            ],
+        )
+
+    def test_group_opening_on_a_nested_group(self):
+        """The first row of a group can itself be a group."""
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        outer = hier.add(Group("outer"))
+        inner = outer.add(Group("inner"))
+        inner.add(Disp("x"))
+        outer.add(Disp("last"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(
+            model.render(),
+            [
+                (0, "group", "outer"),
+                (1, "group", "inner"),
+                (2, "variable", "tb.x"),
+                (1, "variable", "tb.last"),
+            ],
+        )
+
+    def test_dividers_group_like_rows(self):
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        grp = hier.add(Group("g"))
+        grp.add(Divider("section"))
+        grp.add(Disp("a"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(
+            model.render(),
+            [
+                (0, "group", "g"),
+                (1, "divider", "section"),
+                (1, "variable", "tb.a"),
+            ],
+        )
+
+    def test_divider_opening_a_group_keeps_its_real_name(self):
+        """The group's first row is a divider whose name needs renaming."""
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        grp = hier.add(Group("the group"))
+        grp.add(Divider("the divider"))
+        grp.add(Disp("a"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(
+            model.render(),
+            [
+                (0, "group", "the group"),
+                (1, "divider", "the divider"),
+                (1, "variable", "tb.a"),
+            ],
+        )
+
+    def test_properties_land_on_their_own_row(self):
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        hier.add(Disp("plain"))
+        hier.add(Disp("tagged", radix="hexadecimal", color="red"))
+        hier.add(Disp("other"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(model.items[0].properties, {})
+        self.assertEqual(model.items[1].properties, {"format": "Hexadecimal", "color": "Red"})
+        self.assertEqual(model.items[2].properties, {})
+
+    def test_properties_land_on_the_row_that_opened_a_group(self):
+        """That row moves when the group is created; the format must follow."""
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        grp = hier.add(Group("g"))
+        grp.add(Disp("first", radix="binary"))
+        grp.add(Disp("second", radix="octal"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(model.items[0].kind, "group")
+        self.assertEqual(model.items[1].properties, {"format": "Binary"})
+        self.assertEqual(model.items[2].properties, {"format": "Octal"})
+
+    def test_reference_tree_round_trips(self):
+        """The AST shared with the other target tests."""
+        from tests.test_target_surfer import reference_tree
+
+        model = replay(reference_tree())
+        self.assertEqual(model.errors, [])
+        self.assertEqual(
+            model.render(),
+            [
+                (0, "divider", "Clocks"),
+                (0, "variable", "tb.top.clock_main"),
+                (0, "variable", "tb.top.external_pll_valid"),
+                (0, "divider", "The divider"),
+                (0, "group", "reset_group"),
+                (1, "variable", "tb.top.reset_inst.pcie_rstn"),
+                (1, "variable", "tb.top.reset_inst.ethernet_reset"),
+                (0, "group", "reg 0"),
+                (1, "variable", "tb.top.reg_inst.register[0]"),
+                (0, "group", "reg 1"),
+                (1, "variable", "tb.top.reg_inst.register[1]"),
+                (0, "group", "reg 2"),
+                (1, "variable", "tb.top.reg_inst.register[2]"),
+            ],
+        )
+
+    def test_everything_is_unfolded_at_the_end(self):
+        """Folding is a means of navigation here, not a display choice."""
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        outer = hier.add(Group("outer"))
+        inner = outer.add(Group("inner"))
+        inner.add(Disp("x"))
+        model = replay(blk)
+        self.assertTrue(all(item.unfolded for item in model.items))
+
+    def test_nothing_is_focused_at_the_end(self):
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(Disp("a"))
+        self.assertIsNone(replay(blk).focused)
+
+
+class TestReplayCatchesBreakage(unittest.TestCase):
+    """The replay must fail when the arithmetic is wrong.
+
+    A structural test that cannot fail is worth nothing, so the index
+    bookkeeping is broken deliberately here and the replay is required to
+    notice.
+    """
+
+    def setUp(self):
+        ASTBase.reset_unique_id()
+
+    def build(self):
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        grp = hier.add(Group("g"))
+        grp.add(Disp(["a", "b"]))
+        hier.add(Disp("after"))
+        blk.forward()
+        return blk
+
+    def test_a_shifted_index_is_detected(self):
+        """Drop one row from the count, as a failed variable_add would."""
+        good = SurferTarget(self.build()).genstr
+        model = SurferModel()
+        model.run(good)
+        reference = model.render()
+
+        broken = good.replace("variable_add tb.b\n", "", 1)
+        model = SurferModel()
+        model.run(broken)
+        self.assertNotEqual(model.render(), reference)
+
+    def test_dropping_the_fold_is_detected(self):
+        """Without the fold, the row after a group stays inside it."""
+        good = SurferTarget(self.build()).genstr
+        broken = good.replace("group_fold_recursive\n", "", 1)
+        model = SurferModel()
+        model.run(broken)
+        self.assertIn((1, "variable", "tb.after"), model.render())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_surfer_replay.py
+++ b/tests/test_surfer_replay.py
@@ -170,14 +170,27 @@ class SurferModel:
 
     def group_fold_recursive(self):
         index = self.to_item_index(self.focused)
+        if index is None:
+            self.errors.append("group_fold_recursive with nothing focused")
+            return
         item = self.items[index]
         if item.kind != "group":
             self.errors.append(f"group_fold_recursive on a {item.kind}")
             return
+
+        # Surfer drops the focus when the folded group contains the
+        # focused row -- subtree_contains(root, candidate) is
+        # (root..subtree_end(candidate)).contains(candidate), so it holds
+        # for the group itself too, and folding a group you focused in
+        # order to fold it always unfocuses.
+        end = index + 1
+        while end < len(self.items) and self.items[end].level > item.level:
+            end += 1
+        if index <= self.to_item_index(self.focused) < end:
+            self.focused = None
+
         item.unfolded = False
-        for candidate in self.items[index + 1 :]:
-            if candidate.level <= item.level:
-                break
+        for candidate in self.items[index + 1 : end]:
             candidate.unfolded = False
 
     def group_unfold_all(self):
@@ -271,6 +284,38 @@ class TestReplay(unittest.TestCase):
         )
 
     def test_nested_groups(self):
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        outer = hier.add(Group("outer"))
+        outer.add(Disp("first"))
+        inner = outer.add(Group("inner"))
+        inner.add(Disp(["x", "y"]))
+        outer.add(Disp("last"))
+        hier.add(Disp("after"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual(
+            model.render(),
+            [
+                (0, "group", "outer"),
+                (1, "variable", "tb.first"),
+                (1, "group", "inner"),
+                (2, "variable", "tb.x"),
+                (2, "variable", "tb.y"),
+                (1, "variable", "tb.last"),
+                (0, "variable", "tb.after"),
+            ],
+        )
+
+    def test_a_row_after_a_nested_group_stays_in_the_enclosing_group(self):
+        """The case the first dpmemrf run happened not to cover.
+
+        Folding is what returns to the enclosing level, and folding also
+        drops Surfer's focus, so without focusing the folded group again
+        the row lands at the end of the tree at level 0. At top level
+        that is the right place by coincidence; one level in, it escapes
+        the group.
+        """
         blk = Block()
         hier = blk.add(Hierarchy("/tb"))
         outer = hier.add(Group("outer"))

--- a/tests/test_surfer_replay.py
+++ b/tests/test_surfer_replay.py
@@ -125,11 +125,11 @@ class SurferModel:
         before, level = self.insert_position()
         self._insert(Item("variable", path, level), before, level)
 
-    def divider_add(self, name):
+    def divider_add(self, name=" "):
         before, level = self.insert_position()
         self._insert(Item("divider", name, level), before, level)
 
-    def group_marked(self, name):
+    def group_marked(self, name="Group"):
         if self.focused is None:
             return  # no selection and no focus: Surfer does nothing
         before, level = self.insert_position()
@@ -156,7 +156,12 @@ class SurferModel:
     def item_unfocus(self):
         self.focused = None
 
-    def item_rename(self, name):
+    def item_rename(self, name=""):
+        # Surfer trims the line first, so an empty argument is a parse
+        # error and the command is dropped, not applied.
+        if not name.strip():
+            self.errors.append("item_rename with no name")
+            return
         self._focused_item().name = name
 
     def item_set_format(self, value):
@@ -186,7 +191,12 @@ class SurferModel:
         end = index + 1
         while end < len(self.items) and self.items[end].level > item.level:
             end += 1
-        if index <= self.to_item_index(self.focused) < end:
+
+        # No upper bound: subtree_contains(root, candidate) is
+        # (root..subtree_end(candidate)).contains(candidate), which holds
+        # for every candidate at or after root, not only for the ones
+        # inside the folded group.
+        if index <= self.to_item_index(self.focused):
             self.focused = None
 
         item.unfolded = False
@@ -307,37 +317,47 @@ class TestReplay(unittest.TestCase):
             ],
         )
 
-    def test_a_row_after_a_nested_group_stays_in_the_enclosing_group(self):
-        """The case the first dpmemrf run happened not to cover.
+    def test_a_row_after_each_level_of_a_three_deep_nesting(self):
+        """Leaving a group must land at the level that group sat at.
 
-        Folding is what returns to the enclosing level, and folding also
-        drops Surfer's focus, so without focusing the folded group again
-        the row lands at the end of the tree at level 0. At top level
-        that is the right place by coincidence; one level in, it escapes
-        the group.
+        Three levels, with a row after each one, so that returning to
+        level 2, then 1, then 0 is each exercised separately -- folding
+        drops Surfer's focus, and the level it comes back at is only
+        right if the folded group is focused again.
         """
         blk = Block()
         hier = blk.add(Hierarchy("/tb"))
-        outer = hier.add(Group("outer"))
-        outer.add(Disp("first"))
-        inner = outer.add(Group("inner"))
-        inner.add(Disp(["x", "y"]))
-        outer.add(Disp("last"))
-        hier.add(Disp("after"))
+        a = hier.add(Group("a"))
+        b = a.add(Group("b"))
+        c = b.add(Group("c"))
+        c.add(Disp("deep"))
+        b.add(Disp("after_c"))
+        a.add(Disp("after_b"))
+        hier.add(Disp("after_a"))
         model = replay(blk)
         self.assertEqual(model.errors, [])
         self.assertEqual(
             model.render(),
             [
-                (0, "group", "outer"),
-                (1, "variable", "tb.first"),
-                (1, "group", "inner"),
-                (2, "variable", "tb.x"),
-                (2, "variable", "tb.y"),
-                (1, "variable", "tb.last"),
-                (0, "variable", "tb.after"),
+                (0, "group", "a"),
+                (1, "group", "b"),
+                (2, "group", "c"),
+                (3, "variable", "tb.deep"),
+                (2, "variable", "tb.after_c"),
+                (1, "variable", "tb.after_b"),
+                (0, "variable", "tb.after_a"),
             ],
         )
+
+    def test_a_nameless_divider_replays(self):
+        """The argument-less form the empty-name fix emits."""
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        hier.add(Divider("   "))
+        hier.add(Disp("sig"))
+        model = replay(blk)
+        self.assertEqual(model.errors, [])
+        self.assertEqual([i.kind for i in model.items], ["divider", "variable"])
 
     def test_group_opening_on_a_nested_group(self):
         """The first row of a group can itself be a group."""

--- a/tests/test_target_surfer.py
+++ b/tests/test_target_surfer.py
@@ -19,6 +19,8 @@
 
 """Test the Surfer target."""
 
+import subprocess
+import sys
 import unittest
 
 from wavedisp.ast import ASTBase, Block, Disp, Divider, Group, Hierarchy
@@ -340,6 +342,42 @@ class TestSameNamedNestedGroups(unittest.TestCase):
         with self.assertLogs("wavegen", level="WARNING"):
             out = SurferTarget(blk).genstr
         self.assertEqual(out.count("group_marked mem"), 1)
+
+
+class TestOptimisedInterpreter(unittest.TestCase):
+    """The generator must behave identically under `python -O`.
+
+    Assertions are deleted by -O, statement and all, so an assert whose
+    expression does the work silently stops doing it. Here that would
+    leave a finished group on the pending stack, and the next row emitted
+    would be wrapped in a group the wave file never asked for.
+    """
+
+    SCRIPT = (
+        "from wavedisp.ast import ASTBase, Block, Disp, Group, Hierarchy\n"
+        "from wavedisp.targets.surfer import SurferTarget\n"
+        "ASTBase.reset_unique_id()\n"
+        "blk = Block()\n"
+        "hier = blk.add(Hierarchy('/tb'))\n"
+        "hier.add(Group('ghost'))\n"
+        "hier.add(Disp('sig'))\n"
+        "blk.forward()\n"
+        "print(SurferTarget(blk).genstr)\n"
+    )
+
+    def generate(self, *flags):
+        result = subprocess.run(
+            [sys.executable, *flags, "-c", self.SCRIPT],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+
+    def test_an_empty_group_does_not_capture_a_later_row(self):
+        plain = self.generate()
+        self.assertNotIn("group_marked", plain)
+        self.assertEqual(self.generate("-O"), plain)
 
 
 if __name__ == "__main__":

--- a/tests/test_target_surfer.py
+++ b/tests/test_target_surfer.py
@@ -1,0 +1,156 @@
+#
+# This file is part of wavedisp. See the root README.md for further
+# information.
+#
+# wavedisp is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wavedisp is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with wavedisp.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (C) 2019 Christophe Clienti
+
+"""Test the Surfer target."""
+
+import unittest
+
+from wavedisp.ast import ASTBase, Block, Disp, Divider, Group, Hierarchy
+from wavedisp.targets.surfer import SurferTarget, alpha_idx, bare_word
+
+SURFER_GENERATOR_REF = """# Wavedisp generated Surfer command file
+
+divider_add Clocks
+item_focus a
+item_set_color Blue
+variable_add tb.top.clock_main
+item_focus b
+variable_add tb.top.external_pll_valid
+item_focus c
+
+divider_add The_divider
+item_focus d
+item_rename The divider
+variable_add tb.top.reset_inst.pcie_rstn
+item_focus e
+group_marked reset_group
+item_focus f
+item_set_format Binary
+variable_add tb.top.reset_inst.ethernet_reset
+item_focus g
+item_set_format Hexadecimal
+item_focus e
+group_fold_recursive
+variable_add tb.top.reg_inst.register[0]
+item_focus f
+group_marked reg_0
+item_rename reg 0
+item_focus f
+group_fold_recursive
+variable_add tb.top.reg_inst.register[1]
+item_focus g
+group_marked reg_1
+item_rename reg 1
+item_focus g
+group_fold_recursive
+variable_add tb.top.reg_inst.register[2]
+item_focus h
+group_marked reg_2
+item_rename reg 2
+item_focus h
+group_fold_recursive
+
+group_unfold_all
+item_unfocus
+"""
+
+
+def reference_tree():
+    """Build the AST the other target tests use, trimmed to three registers.
+
+    Returned unforwarded: forward() is not idempotent, it prepends the
+    hierarchy again on a second call.
+    """
+    ASTBase.reset_unique_id()
+
+    testbench = Hierarchy("/tb")
+    testbench.add(Divider("Clocks", color="blue"))
+
+    top = testbench.add(Hierarchy("top"))
+    top.add(Disp(["clock_main", "external_pll_valid"]))
+    top.add(Divider("The divider"))
+
+    group = top.add(Group("reset_group", radix="binary"))
+    group.add(Disp("reset_inst/pcie_rstn"))
+    group.add(Disp("reset_inst/ethernet_reset", radix="hexadecimal"))
+
+    hier = top.add(Hierarchy("reg_inst"))
+    for i in range(0, 3):
+        grp = hier.add(Group(f"reg {i}"))
+        blk = grp.add(Block())
+        blk.add(Disp(f"register[{i}]"))
+
+    return testbench
+
+
+class TestSurferTarget(unittest.TestCase):
+    """Golden output for the Surfer generator."""
+
+    def test_target_surfer(self):
+        """Test the surfer generator."""
+
+        self.maxDiff = None
+
+        tree = reference_tree()
+        tree.forward()
+        surfer = SurferTarget(tree)
+        with open("test_target_surfer.sucl", "w") as fcmd:
+            fcmd.write(surfer.genstr)
+
+        self.assertEqual(surfer.genstr, SURFER_GENERATOR_REF)
+
+
+class TestAlphaIdx(unittest.TestCase):
+    """Surfer names a row by its index written in hexadecimal over a-p."""
+
+    def test_single_digit(self):
+        self.assertEqual(alpha_idx(0), "a")
+        self.assertEqual(alpha_idx(1), "b")
+        self.assertEqual(alpha_idx(15), "p")
+
+    def test_multiple_digits(self):
+        self.assertEqual(alpha_idx(16), "ba")
+        self.assertEqual(alpha_idx(255), "pp")
+        self.assertEqual(alpha_idx(256), "baa")
+
+    def test_round_trip(self):
+        """Reproduce Surfer's own decoding: map back to hex, read base 16."""
+        for index in list(range(0, 300)) + [1000, 4095, 65535]:
+            decoded = "".join(f"{ord(c) - ord('a'):x}" for c in alpha_idx(index))
+            self.assertEqual(int(decoded, 16), index)
+
+
+class TestBareWord(unittest.TestCase):
+    """divider_add and group_marked take a single \\w+ word, or nothing."""
+
+    def test_word_is_kept(self):
+        self.assertEqual(bare_word("reset_group", "group"), "reset_group")
+
+    def test_spaces_and_punctuation_collapse(self):
+        self.assertEqual(bare_word("reg 0", "group"), "reg_0")
+        self.assertEqual(bare_word("lut_gen[0].inst", "group"), "lut_gen_0_inst")
+        self.assertEqual(bare_word("A/B", "group"), "A_B")
+
+    def test_empty_falls_back(self):
+        self.assertEqual(bare_word("...", "group"), "group")
+        self.assertEqual(bare_word("", "divider"), "divider")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_target_surfer.py
+++ b/tests/test_target_surfer.py
@@ -24,6 +24,7 @@ import sys
 import unittest
 
 from wavedisp.ast import ASTBase, Block, Disp, Divider, Group, Hierarchy
+from wavedisp.targets import TargetOptionError
 from wavedisp.targets.surfer import (
     SURFER_LINE_HEIGHT,
     SurferTarget,
@@ -378,6 +379,69 @@ class TestOptimisedInterpreter(unittest.TestCase):
         plain = self.generate()
         self.assertNotIn("group_marked", plain)
         self.assertEqual(self.generate("-O"), plain)
+
+
+class TestNamesSurferCannotCarry(unittest.TestCase):
+    """A name that survives neither the add command nor a rename."""
+
+    def setUp(self):
+        ASTBase.reset_unique_id()
+
+    def build(self, node):
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(node)
+        blk.forward()
+        return blk
+
+    def test_a_whitespace_name_emits_no_rename(self):
+        """Surfer trims the line, so the argument would be gone."""
+        out = SurferTarget(self.build(Divider("   "))).genstr
+        self.assertNotIn("item_rename", out)
+        self.assertIn("divider_add\n", out)
+
+    def test_a_punctuation_name_is_still_renamed(self):
+        """Empty *word*, but a name that can be carried."""
+        out = SurferTarget(self.build(Divider("---"))).genstr
+        self.assertIn("divider_add\n", out)
+        self.assertIn("item_rename ---\n", out)
+
+    def test_a_nameless_group_is_reported(self):
+        """Surfer substitutes the literal "Group" and cannot be told otherwise."""
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(Group("")).add(Disp("sig"))
+        blk.forward()
+        with self.assertLogs("wavegen", level="WARNING") as logs:
+            out = SurferTarget(blk).genstr
+        self.assertIn("Group", logs.output[0])
+        self.assertIn("group_marked\n", out)
+        self.assertNotIn("item_rename", out)
+
+
+class TestLineHeightEdgeValues(unittest.TestCase):
+    """json can express more numbers than the guard used to reject."""
+
+    def setUp(self):
+        ASTBase.reset_unique_id()
+        self.blk = Block()
+        self.blk.add(Hierarchy("/tb")).add(Disp("sig", height=32))
+        self.blk.forward()
+
+    def test_a_boolean_is_refused(self):
+        """bool is a subclass of int, so float(True) would be 1.0."""
+        for value in (True, False):
+            with self.subTest(value=value), self.assertRaises(TargetOptionError):
+                SurferTarget(self.blk, line_height=value)
+
+    def test_non_finite_values_are_refused(self):
+        """Python's json accepts Infinity and NaN; nan <= 0 is False."""
+        for value in (float("inf"), float("-inf"), float("nan")):
+            with self.subTest(value=value), self.assertRaises(TargetOptionError):
+                SurferTarget(self.blk, line_height=value)
+
+    def test_the_error_is_the_dedicated_type(self):
+        """So the CLI can catch it without swallowing generation errors."""
+        with self.assertRaises(TargetOptionError):
+            SurferTarget(self.blk, line_height=0)
 
 
 if __name__ == "__main__":

--- a/tests/test_target_surfer.py
+++ b/tests/test_target_surfer.py
@@ -22,7 +22,15 @@
 import unittest
 
 from wavedisp.ast import ASTBase, Block, Disp, Divider, Group, Hierarchy
-from wavedisp.targets.surfer import SURFER_LINE_HEIGHT, SurferTarget, alpha_idx, bare_word, height_scale
+from wavedisp.targets.surfer import (
+    SURFER_LINE_HEIGHT,
+    SurferTarget,
+    alpha_idx,
+    bare_word,
+    command_text,
+    height_scale,
+    representable_path,
+)
 
 SURFER_GENERATOR_REF = """# Wavedisp generated Surfer command file
 
@@ -47,24 +55,28 @@ item_focus g
 item_set_format Hexadecimal
 item_focus e
 group_fold_recursive
+item_focus e
 variable_add tb.top.reg_inst.register[0]
 item_focus f
 group_marked reg_0
 item_rename reg 0
 item_focus f
 group_fold_recursive
+item_focus f
 variable_add tb.top.reg_inst.register[1]
 item_focus g
 group_marked reg_1
 item_rename reg 1
 item_focus g
 group_fold_recursive
+item_focus g
 variable_add tb.top.reg_inst.register[2]
 item_focus h
 group_marked reg_2
 item_rename reg 2
 item_focus h
 group_fold_recursive
+item_focus h
 
 group_unfold_all
 item_unfocus
@@ -140,20 +152,17 @@ class TestBareWord(unittest.TestCase):
     """divider_add and group_marked take a single \\w+ word, or nothing."""
 
     def test_word_is_kept(self):
-        self.assertEqual(bare_word("reset_group", "group"), "reset_group")
+        self.assertEqual(bare_word("reset_group"), "reset_group")
 
     def test_spaces_and_punctuation_collapse(self):
-        self.assertEqual(bare_word("reg 0", "group"), "reg_0")
-        self.assertEqual(bare_word("lut_gen[0].inst", "group"), "lut_gen_0_inst")
-        self.assertEqual(bare_word("A/B", "group"), "A_B")
+        self.assertEqual(bare_word("reg 0"), "reg_0")
+        self.assertEqual(bare_word("lut_gen[0].inst"), "lut_gen_0_inst")
+        self.assertEqual(bare_word("A/B"), "A_B")
 
-    def test_empty_falls_back(self):
-        self.assertEqual(bare_word("...", "group"), "group")
-        self.assertEqual(bare_word("", "divider"), "divider")
-
-
-if __name__ == "__main__":
-    unittest.main()
+    def test_a_nameless_item_yields_an_empty_word(self):
+        """The argument is optional; omitting it is how it is said."""
+        self.assertEqual(bare_word("..."), "")
+        self.assertEqual(bare_word(""), "")
 
 
 class TestHeightScale(unittest.TestCase):
@@ -215,3 +224,123 @@ class TestHeightPlacement(unittest.TestCase):
         blk.add(Hierarchy("/tb")).add(Divider("d", height=32))
         blk.forward()
         self.assertNotIn("item_set_height", SurferTarget(blk).genstr)
+
+
+class TestUnrepresentableCharacters(unittest.TestCase):
+    """A command file is split on lines, then ";", then truncated at "#".
+
+    None of the three can be escaped, so a name carrying one of those
+    characters has no faithful spelling at all. Names are substituted --
+    a recognisable wrong name beats a truncated one -- but a *path* is
+    dropped, because a renamed path names a signal that is not in the
+    dump and Surfer would add no row where the target counted one.
+    """
+
+    def test_a_name_is_substituted_and_reported(self):
+        for text in ("a#b", "a;b", "a\nb", "a\rb"):
+            with self.subTest(text=text), self.assertLogs("wavegen", level="ERROR"):
+                self.assertEqual(command_text(text, "ctx"), "a_b")
+
+    def test_a_clean_name_is_untouched_and_silent(self):
+        self.assertEqual(command_text("port A -- inputs", "ctx"), "port A -- inputs")
+
+    def test_a_path_carrying_one_is_refused(self):
+        for path in ("tb.a#b", "tb.a;b", "tb.a\nb"):
+            with self.subTest(path=path), self.assertLogs("wavegen", level="ERROR"):
+                self.assertFalse(representable_path(path, "ctx"))
+
+    def test_a_clean_path_is_accepted(self):
+        self.assertTrue(representable_path("tb.dut.sig[3:0]", "ctx"))
+
+    def test_the_dropped_signal_does_not_shift_the_rows_after_it(self):
+        """The whole point: the count must match what Surfer will build."""
+        ASTBase.reset_unique_id()
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        hier.add(Disp(["good", "ba#d", "after"]))
+        blk.forward()
+        with self.assertLogs("wavegen", level="ERROR"):
+            out = SurferTarget(blk).genstr
+        self.assertNotIn("ba_d", out)
+        self.assertIn("variable_add tb.good\nitem_focus a\n", out)
+        self.assertIn("variable_add tb.after\nitem_focus b\n", out)
+
+
+class TestNamelessItems(unittest.TestCase):
+    """An item whose name has no word character at all."""
+
+    def setUp(self):
+        ASTBase.reset_unique_id()
+
+    def test_a_nameless_divider_is_added_without_an_argument(self):
+        """item_rename with an empty argument is a parse error."""
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(Divider("---"))
+        blk.forward()
+        out = SurferTarget(blk).genstr
+        self.assertIn("divider_add\n", out)
+        self.assertNotIn("item_rename\n", out)
+        self.assertNotIn("item_rename \n", out)
+
+    def test_a_named_divider_still_gets_its_name_back(self):
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(Divider("the divider"))
+        blk.forward()
+        self.assertIn("item_rename the divider\n", SurferTarget(blk).genstr)
+
+
+class TestRadixMapping(unittest.TestCase):
+    def test_string_maps_to_ascii(self):
+        """Surfer's String translator answers ERROR for a vector."""
+        self.assertEqual(SurferTarget.RadixDict["string"], "ASCII")
+
+    def test_every_wavedisp_radix_is_mapped(self):
+        self.assertEqual(
+            set(SurferTarget.RadixDict),
+            {"binary", "hexadecimal", "signed", "unsigned", "octal", "string", "symbolic"},
+        )
+
+
+class TestLineHeightValidation(unittest.TestCase):
+    """line_height arrives from user JSON, so it is checked not divided by."""
+
+    def setUp(self):
+        ASTBase.reset_unique_id()
+        self.blk = Block()
+        self.blk.add(Hierarchy("/tb")).add(Disp("sig", height=32))
+        self.blk.forward()
+
+    def test_zero_is_refused(self):
+        with self.assertRaises(ValueError):
+            SurferTarget(self.blk, line_height=0)
+
+    def test_a_negative_value_is_refused(self):
+        with self.assertRaises(ValueError):
+            SurferTarget(self.blk, line_height=-16)
+
+    def test_a_non_number_is_refused(self):
+        with self.assertRaises(ValueError):
+            SurferTarget(self.blk, line_height="tall")
+
+    def test_a_quoted_number_is_accepted(self):
+        """A natural JSON typo, and harmless once converted."""
+        self.assertIn("item_set_height 2\n", SurferTarget(self.blk, line_height="16").genstr)
+
+
+class TestSameNamedNestedGroups(unittest.TestCase):
+    def test_a_group_nested_in_a_same_named_group(self):
+        """The pending entries hold equal values; only identity tells them apart."""
+        ASTBase.reset_unique_id()
+        blk = Block()
+        hier = blk.add(Hierarchy("/tb"))
+        outer = hier.add(Group("mem"))
+        outer.add(Group("mem"))
+        outer.add(Disp("a"))
+        blk.forward()
+        with self.assertLogs("wavegen", level="WARNING"):
+            out = SurferTarget(blk).genstr
+        self.assertEqual(out.count("group_marked mem"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_target_surfer.py
+++ b/tests/test_target_surfer.py
@@ -22,7 +22,7 @@
 import unittest
 
 from wavedisp.ast import ASTBase, Block, Disp, Divider, Group, Hierarchy
-from wavedisp.targets.surfer import SurferTarget, alpha_idx, bare_word
+from wavedisp.targets.surfer import SURFER_LINE_HEIGHT, SurferTarget, alpha_idx, bare_word, height_scale
 
 SURFER_GENERATOR_REF = """# Wavedisp generated Surfer command file
 
@@ -154,3 +154,64 @@ class TestBareWord(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestHeightScale(unittest.TestCase):
+    """A height is pixels for Modelsim, a line-height factor for Surfer.
+
+    Surfer draws a row `waveforms_line_height * factor` tall and clamps
+    nothing, so dividing by that line height reproduces the pixel height
+    the other targets would have given.
+    """
+
+    def test_the_default_reference_is_surfers_own(self):
+        self.assertEqual(SURFER_LINE_HEIGHT, 16.0)
+
+    def test_a_multiple_comes_out_without_a_decimal_point(self):
+        self.assertEqual(height_scale(32, 16.0, "ctx"), "2")
+        self.assertEqual(height_scale(16, 16.0, "ctx"), "1")
+
+    def test_a_ratio_is_kept(self):
+        self.assertEqual(height_scale(30, 16.0, "ctx"), "1.875")
+        self.assertEqual(height_scale(8, 16.0, "ctx"), "0.5")
+
+    def test_a_string_height_is_accepted(self):
+        """Properties are free-form, and a wave file may quote the value."""
+        self.assertEqual(height_scale("32", 16.0, "ctx"), "2")
+
+    def test_a_configured_line_height_is_honoured(self):
+        self.assertEqual(height_scale(32, 8.0, "ctx"), "4")
+
+    def test_a_bad_height_is_reported_not_emitted(self):
+        with self.assertLogs("wavegen", level="ERROR"):
+            self.assertIsNone(height_scale("tall", 16.0, "ctx"))
+        with self.assertLogs("wavegen", level="ERROR"):
+            self.assertIsNone(height_scale(0, 16.0, "ctx"))
+        with self.assertLogs("wavegen", level="ERROR"):
+            self.assertIsNone(height_scale(-4, 16.0, "ctx"))
+
+
+class TestHeightPlacement(unittest.TestCase):
+    """Where a height may and may not be emitted."""
+
+    def setUp(self):
+        ASTBase.reset_unique_id()
+
+    def test_a_signal_gets_the_converted_factor(self):
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(Disp("sig", height=32))
+        blk.forward()
+        self.assertIn("item_set_height 2\n", SurferTarget(blk).genstr)
+
+    def test_the_reference_is_configurable(self):
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(Disp("sig", height=32))
+        blk.forward()
+        self.assertIn("item_set_height 4\n", SurferTarget(blk, line_height=8.0).genstr)
+
+    def test_a_divider_gets_no_height(self):
+        """set_height_scaling_factor ignores every item but a variable."""
+        blk = Block()
+        blk.add(Hierarchy("/tb")).add(Divider("d", height=32))
+        blk.forward()
+        self.assertNotIn("item_set_height", SurferTarget(blk).genstr)

--- a/wavedisp/cli.py
+++ b/wavedisp/cli.py
@@ -25,6 +25,7 @@ import json
 import logging
 
 from wavedisp.ast import Block
+from wavedisp.targets import TargetOptionError
 from wavedisp.targets.gtkwave import GTKWaveTarget
 from wavedisp.targets.modelsim import ModelsimTarget
 from wavedisp.targets.rivierapro import RivieraProTarget
@@ -39,6 +40,30 @@ TARGETS = {
     "rivierapro": RivieraProTarget,
     "surfer": SurferTarget,
 }
+
+
+def decode_kwargs(text, option, logger):
+    """Decode one of the json dictionaries the command line takes.
+
+    :return: the dictionary, or None if it was not one.
+
+    """
+
+    try:
+        decoded = json.loads(text)
+    except json.JSONDecodeError as error:
+        logger.error("%s is not valid json: %s", option, error)
+        return None
+
+    if not isinstance(decoded, dict):
+        logger.error(
+            "%s must be a json object, got %s",
+            option,
+            type(decoded).__name__ if decoded is not None else "null",
+        )
+        return None
+
+    return decoded
 
 
 def check_target_kwargs(name, accepted, kwargs, logger):
@@ -97,9 +122,10 @@ def make_target(name, tree, logger, kwargs):
 
     try:
         return target_class(tree, **kwargs)
-    except ValueError as error:
-        # A target validates its own options; it cannot report them,
-        # since it has no logger and is used outside the CLI too.
+    except TargetOptionError as error:
+        # Only that type: a target does all of its work in __init__, so
+        # catching ValueError here would also swallow one raised
+        # anywhere in the traversal and blame it on an option.
         logger.error('target "%s": %s', name, error)
         return None
 
@@ -164,10 +190,14 @@ def main():
 
     # -a goes to the generator function in the input file, -T to the
     # target class: one parameterises the description, the other how it
-    # is rendered.
-    kwargs = json.loads(args.kwargs)
+    # is rendered. Both are user-written json, so neither is decoded
+    # straight into a subscript or a splat.
+    kwargs = decode_kwargs(args.kwargs, "-a/--kwargs", logger)
+    target_kwargs = decode_kwargs(args.target_kwargs, "-T/--target-kwargs", logger)
+    if kwargs is None or target_kwargs is None:
+        exit(1)
+
     kwargs["__generator"] = args.generator
-    target_kwargs = json.loads(args.target_kwargs)
 
     block = Block(__filename=args.input, __line=0)
     block.include(args.input, **kwargs)

--- a/wavedisp/cli.py
+++ b/wavedisp/cli.py
@@ -53,6 +53,13 @@ def check_target_kwargs(name, accepted, kwargs, logger):
 
     """
 
+    if not isinstance(kwargs, dict):
+        logger.error(
+            "target arguments must be a json object, got %s",
+            type(kwargs).__name__ if kwargs is not None else "null",
+        )
+        return False
+
     unknown = sorted(set(kwargs) - set(accepted))
     if not unknown:
         return True
@@ -66,8 +73,13 @@ def check_target_kwargs(name, accepted, kwargs, logger):
     return False
 
 
-def make_target(name, tree, logger, **kwargs):
+def make_target(name, tree, logger, kwargs):
     """Instantiate the target ``name`` over ``tree``.
+
+    ``kwargs`` is taken as a dictionary rather than as ``**kwargs``, so
+    that a --target-kwargs key happening to be called "name", "tree" or
+    "logger" is reported like any other unknown option instead of
+    colliding with this function's own parameters.
 
     :return: the target instance, or None if it could not be built.
 
@@ -83,7 +95,13 @@ def make_target(name, tree, logger, **kwargs):
     if not check_target_kwargs(name, set(parameters) - {"self", "tree"}, kwargs, logger):
         return None
 
-    return target_class(tree, **kwargs)
+    try:
+        return target_class(tree, **kwargs)
+    except ValueError as error:
+        # A target validates its own options; it cannot report them,
+        # since it has no logger and is used outside the CLI too.
+        logger.error('target "%s": %s', name, error)
+        return None
 
 
 class LoggingLevelCounterHandler(logging.Handler):
@@ -166,7 +184,7 @@ def main():
         fmod.close()
         exit(0)
 
-    target = make_target(args.target, block, logger, **target_kwargs)
+    target = make_target(args.target, block, logger, target_kwargs)
     if target is None:
         exit(1)
 

--- a/wavedisp/cli.py
+++ b/wavedisp/cli.py
@@ -20,6 +20,7 @@
 """Command line interface."""
 
 import argparse
+import inspect
 import json
 import logging
 
@@ -27,7 +28,50 @@ from wavedisp.ast import Block
 from wavedisp.targets.gtkwave import GTKWaveTarget
 from wavedisp.targets.modelsim import ModelsimTarget
 from wavedisp.targets.rivierapro import RivieraProTarget
-from wavedisp.targets.surfer import SURFER_LINE_HEIGHT, SurferTarget
+from wavedisp.targets.surfer import SurferTarget
+
+#: Targets that turn an AST into a file, by the name -t takes. "dot" is
+#: not here: it renders the AST itself rather than going through a
+#: target class.
+TARGETS = {
+    "gtkwave": GTKWaveTarget,
+    "modelsim": ModelsimTarget,
+    "rivierapro": RivieraProTarget,
+    "surfer": SurferTarget,
+}
+
+
+def make_target(name, tree, logger, **kwargs):
+    """Instantiate the target ``name`` over ``tree``.
+
+    The keyword arguments come from --target-kwargs, so they are checked
+    against what the target actually takes rather than passed straight
+    in: an option meant for another target would otherwise surface as a
+    TypeError traceback, and one silently accepted would be worse.
+
+    :return: the target instance, or None if it could not be built.
+
+    """
+
+    try:
+        target_class = TARGETS[name]
+    except KeyError:
+        logger.error('target "%s" not supported', name)
+        return None
+
+    parameters = inspect.signature(target_class.__init__).parameters
+    accepted = set(parameters) - {"self", "tree"}
+    unknown = sorted(set(kwargs) - accepted)
+    if unknown:
+        logger.error(
+            'target "%s" does not accept %s (it takes %s)',
+            name,
+            ", ".join(f'"{key}"' for key in unknown),
+            ", ".join(f'"{key}"' for key in sorted(accepted)) if accepted else "no option",
+        )
+        return None
+
+    return target_class(tree, **kwargs)
 
 
 class LoggingLevelCounterHandler(logging.Handler):
@@ -67,16 +111,7 @@ def main():
         "-g", "--generator", type=str, default="generator", help="generator function name in the input file"
     )
     parser.add_argument("-a", "--kwargs", default="{}", help="arguments dictionary for the generator function in json")
-    parser.add_argument(
-        "--surfer-line-height",
-        type=float,
-        default=SURFER_LINE_HEIGHT,
-        help=(
-            "pixel height of one Surfer row, used to convert the height property "
-            "into the factor Surfer takes; match it to layout.waveforms_line_height "
-            "if your Surfer configuration changes it"
-        ),
-    )
+    parser.add_argument("-T", "--target-kwargs", default="{}", help="arguments dictionary for the target in json")
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose mode")
     parser.add_argument("-d", "--debug", action="store_true", help="debug mode")
 
@@ -97,28 +132,25 @@ def main():
 
     logger = logging.getLogger("wavegen:cli")
 
+    # -a goes to the generator function in the input file, -T to the
+    # target class: one parameterises the description, the other how it
+    # is rendered.
     kwargs = json.loads(args.kwargs)
     kwargs["__generator"] = args.generator
+    target_kwargs = json.loads(args.target_kwargs)
 
     block = Block(__filename=args.input, __line=0)
     block.include(args.input, **kwargs)
     block.forward()
 
-    if args.target == "gtkwave":
-        target = GTKWaveTarget(block)
-    elif args.target == "modelsim":
-        target = ModelsimTarget(block)
-    elif args.target == "rivierapro":
-        target = RivieraProTarget(block)
-    elif args.target == "surfer":
-        target = SurferTarget(block, line_height=args.surfer_line_height)
-    elif args.target == "dot":
+    if args.target == "dot":
         fmod = open(args.output, "w")
         fmod.write(str(block.children[0]))
         fmod.close()
         exit(0)
-    else:
-        logger.error('target "%s" not supported', args.target)
+
+    target = make_target(args.target, block, logger, **target_kwargs)
+    if target is None:
         exit(1)
 
     try:

--- a/wavedisp/cli.py
+++ b/wavedisp/cli.py
@@ -41,13 +41,33 @@ TARGETS = {
 }
 
 
+def check_target_kwargs(name, accepted, kwargs, logger):
+    """Report the --target-kwargs entries ``name`` has no use for.
+
+    An option is checked rather than passed straight in, because every
+    other outcome is silent or ugly: handed to a target that does not
+    take it, it raises a TypeError traceback, and merely ignored it
+    produces a file that quietly lacks the requested layout.
+
+    :return: True when every key is accepted.
+
+    """
+
+    unknown = sorted(set(kwargs) - set(accepted))
+    if not unknown:
+        return True
+
+    logger.error(
+        'target "%s" does not accept %s (it takes %s)',
+        name,
+        ", ".join(f'"{key}"' for key in unknown),
+        ", ".join(f'"{key}"' for key in sorted(accepted)) if accepted else "no option",
+    )
+    return False
+
+
 def make_target(name, tree, logger, **kwargs):
     """Instantiate the target ``name`` over ``tree``.
-
-    The keyword arguments come from --target-kwargs, so they are checked
-    against what the target actually takes rather than passed straight
-    in: an option meant for another target would otherwise surface as a
-    TypeError traceback, and one silently accepted would be worse.
 
     :return: the target instance, or None if it could not be built.
 
@@ -60,15 +80,7 @@ def make_target(name, tree, logger, **kwargs):
         return None
 
     parameters = inspect.signature(target_class.__init__).parameters
-    accepted = set(parameters) - {"self", "tree"}
-    unknown = sorted(set(kwargs) - accepted)
-    if unknown:
-        logger.error(
-            'target "%s" does not accept %s (it takes %s)',
-            name,
-            ", ".join(f'"{key}"' for key in unknown),
-            ", ".join(f'"{key}"' for key in sorted(accepted)) if accepted else "no option",
-        )
+    if not check_target_kwargs(name, set(parameters) - {"self", "tree"}, kwargs, logger):
         return None
 
     return target_class(tree, **kwargs)
@@ -144,6 +156,11 @@ def main():
     block.forward()
 
     if args.target == "dot":
+        # Rendered straight from the AST, with no target class to carry
+        # an option -- but it still has to refuse one rather than write
+        # the file as if it had been applied.
+        if not check_target_kwargs("dot", set(), target_kwargs, logger):
+            exit(1)
         fmod = open(args.output, "w")
         fmod.write(str(block.children[0]))
         fmod.close()

--- a/wavedisp/cli.py
+++ b/wavedisp/cli.py
@@ -27,6 +27,7 @@ from wavedisp.ast import Block
 from wavedisp.targets.gtkwave import GTKWaveTarget
 from wavedisp.targets.modelsim import ModelsimTarget
 from wavedisp.targets.rivierapro import RivieraProTarget
+from wavedisp.targets.surfer import SurferTarget
 
 
 class LoggingLevelCounterHandler(logging.Handler):
@@ -59,7 +60,7 @@ def main():
         default="gtkwave",
         help=(
             "targeted simulator for the generated waveforms file, "
-            "available targets: gtkwave, modelsim, rivierapro and dot (graphviz)"
+            "available targets: gtkwave, modelsim, rivierapro, surfer and dot (graphviz)"
         ),
     )
     parser.add_argument(
@@ -99,6 +100,8 @@ def main():
         target = ModelsimTarget(block)
     elif args.target == "rivierapro":
         target = RivieraProTarget(block)
+    elif args.target == "surfer":
+        target = SurferTarget(block)
     elif args.target == "dot":
         fmod = open(args.output, "w")
         fmod.write(str(block.children[0]))

--- a/wavedisp/cli.py
+++ b/wavedisp/cli.py
@@ -27,7 +27,7 @@ from wavedisp.ast import Block
 from wavedisp.targets.gtkwave import GTKWaveTarget
 from wavedisp.targets.modelsim import ModelsimTarget
 from wavedisp.targets.rivierapro import RivieraProTarget
-from wavedisp.targets.surfer import SurferTarget
+from wavedisp.targets.surfer import SURFER_LINE_HEIGHT, SurferTarget
 
 
 class LoggingLevelCounterHandler(logging.Handler):
@@ -67,6 +67,16 @@ def main():
         "-g", "--generator", type=str, default="generator", help="generator function name in the input file"
     )
     parser.add_argument("-a", "--kwargs", default="{}", help="arguments dictionary for the generator function in json")
+    parser.add_argument(
+        "--surfer-line-height",
+        type=float,
+        default=SURFER_LINE_HEIGHT,
+        help=(
+            "pixel height of one Surfer row, used to convert the height property "
+            "into the factor Surfer takes; match it to layout.waveforms_line_height "
+            "if your Surfer configuration changes it"
+        ),
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose mode")
     parser.add_argument("-d", "--debug", action="store_true", help="debug mode")
 
@@ -101,7 +111,7 @@ def main():
     elif args.target == "rivierapro":
         target = RivieraProTarget(block)
     elif args.target == "surfer":
-        target = SurferTarget(block)
+        target = SurferTarget(block, line_height=args.surfer_line_height)
     elif args.target == "dot":
         fmod = open(args.output, "w")
         fmod.write(str(block.children[0]))

--- a/wavedisp/targets/__init__.py
+++ b/wavedisp/targets/__init__.py
@@ -18,3 +18,14 @@
 # Copyright (C) 2019 Christophe Clienti
 
 """Wavedisp targets initialization."""
+
+
+class TargetOptionError(ValueError):
+    """A target was given an option value it cannot use.
+
+    Its own type, rather than a plain ValueError, so that the caller
+    reporting bad --target-kwargs catches only that. A target does all of
+    its work in ``__init__``, so catching ValueError around the
+    construction would also swallow one raised anywhere in the traversal
+    and blame it on an option the user did pass correctly.
+    """

--- a/wavedisp/targets/gtkwave.py
+++ b/wavedisp/targets/gtkwave.py
@@ -17,7 +17,7 @@
 #
 # Copyright (C) 2019 Christophe Clienti
 
-"""Generator for the GTKWave viewer."""
+"""Target for the GTKWave viewer."""
 
 import logging
 
@@ -82,7 +82,7 @@ def highlight_added(var):
 
 
 class GTKWaveTarget(Visitor):
-    """Code generator for the GTKWave viewer."""
+    """Target for the GTKWave viewer."""
 
     RadixDict = {
         "binary": "Binary",

--- a/wavedisp/targets/modelsim.py
+++ b/wavedisp/targets/modelsim.py
@@ -17,7 +17,7 @@
 #
 # Copyright (C) 2019 Christophe Clienti
 
-"""Generator for the Modelsim viewer."""
+"""Target for the Modelsim viewer."""
 
 import logging
 
@@ -28,7 +28,7 @@ LOGGER = logging.getLogger("wavegen")
 
 
 class ModelsimTarget(Visitor):
-    """Code generator for the Modelsim viewer."""
+    """Target for the Modelsim viewer."""
 
     RadixDict = {
         "binary": "binary",

--- a/wavedisp/targets/rivierapro.py
+++ b/wavedisp/targets/rivierapro.py
@@ -17,7 +17,7 @@
 #
 # Copyright (C) 2019 Christophe Clienti
 
-"""Generator for the RivieraPro viewer."""
+"""Target for the RivieraPro viewer."""
 
 import logging
 
@@ -28,7 +28,7 @@ LOGGER = logging.getLogger("wavegen")
 
 
 class RivieraProTarget(Visitor):
-    """Code generator for the RivieraPro viewer."""
+    """Target for the RivieraPro viewer."""
 
     RadixDict = {
         "binary": "-binary",

--- a/wavedisp/targets/surfer.py
+++ b/wavedisp/targets/surfer.py
@@ -54,27 +54,59 @@ def alpha_idx(index):
     return "".join(chr(ord("a") + int(digit, 16)) for digit in f"{index:x}")
 
 
+#: The characters a command file cannot carry anywhere, at all. It is
+#: split into lines, then on ``;``, then truncated at ``#``, before any
+#: command is parsed, and the splitter has no quoting or escaping -- so
+#: there is no spelling of a name or a path containing one of these that
+#: survives.
+UNREPRESENTABLE = "#;\n\r"
+
+
 def command_text(text, context):
     """Return ``text`` as a Surfer command file can carry it.
 
-    A command file is split on newlines and on ``;``, and everything
-    after a ``#`` is dropped, before any command is parsed. Those two
-    characters are removed by the splitter itself, and the splitter has
-    no quoting or escaping whatsoever -- there is no spelling of a name
-    containing them that survives. They are replaced here so the rest of
-    the file still parses, and reported, since the result is not what the
-    user asked for.
+    Used for names, where something wrong is better than something
+    truncated: left alone, ``clock#0`` reaches Surfer as ``clock`` and
+    ``clock;0`` as ``clock`` plus a line Surfer rejects as an unknown
+    command. Substituting keeps the name recognisable and reports that it
+    was changed.
+
+    Paths get the opposite treatment -- see representable_path.
     """
-    if "#" in text or ";" in text:
+    if any(char in text for char in UNREPRESENTABLE):
         LOGGER.error(
-            '%s: "#" and ";" cannot be represented in a Surfer command file, replaced by "_" in "%s"', context, text
+            '%s: a Surfer command file cannot carry "#", ";" or a newline, replaced by "_" in "%s"',
+            context,
+            text,
         )
-        text = text.replace("#", "_").replace(";", "_")
+        for char in UNREPRESENTABLE:
+            text = text.replace(char, "_")
 
     return text
 
 
-def bare_word(text, fallback):
+def representable_path(path, context):
+    """Whether ``path`` can be named in a command file at all.
+
+    A substitution is right for a name and wrong for a signal path: the
+    renamed row is still the row the user meant, but a *renamed path*
+    names a signal that does not exist, so Surfer adds no row while the
+    target counts one -- and from there every predicted index is off by
+    one, which moves the properties and groups of everything after it.
+    Dropping the one signal keeps the rest of the file correct.
+    """
+    if any(char in path for char in UNREPRESENTABLE):
+        LOGGER.error(
+            '%s: a Surfer command file cannot carry "#", ";" or a newline, dropping signal "%s"',
+            context,
+            path,
+        )
+        return False
+
+    return True
+
+
+def bare_word(text):
     """Return ``text`` reduced to what ``divider_add`` and ``group_marked`` accept.
 
     Those two take an *optional* argument, which Surfer parses as a
@@ -85,11 +117,29 @@ def bare_word(text, fallback):
 
     The caller pairs this with an ``item_rename``, which takes the rest
     of the line and restores the real name -- the reduced word is never
-    what ends up on screen.
+    what ends up on screen. An empty result is returned as such: the
+    argument is optional, and omitting it is how an unnamed item is
+    asked for.
     """
-    word = re.sub(r"\W+", "_", text, flags=re.ASCII).strip("_")
+    return re.sub(r"\W+", "_", text, flags=re.ASCII).strip("_")
 
-    return word if word else fallback
+
+class PendingGroup:
+    """A group entered but not yet created.
+
+    A group cannot be created empty -- ``group_marked`` with nothing
+    focused does nothing at all -- so it waits here until the first row
+    inside it is emitted, and latches onto that row.
+
+    A class rather than a dict so that identity is what distinguishes
+    two of them: two groups of the same name hold equal values, and a
+    list operation comparing by value would confuse them.
+    """
+
+    def __init__(self, name):
+        self.name = name
+        self.word = bare_word(name)
+        self.header = None
 
 
 #: Surfer's ``layout.waveforms_line_height`` default, in pixels. It is
@@ -146,7 +196,12 @@ class SurferTarget(Visitor):
         "signed": "Signed",
         "unsigned": "Unsigned",
         "octal": "Octal",
-        "string": "String",
+        # ASCII, not String: Surfer's StringTranslator is for variables
+        # that carry a string, and answers "ERROR (0x...)" for the
+        # BigUint a VCD or FST vector loads as. ASCIITranslator is the
+        # one that renders bits as characters, like Modelsim's "ascii"
+        # and GTKWave's "ASCII".
+        "string": "ASCII",
         "symbolic": "Enum",
     }
 
@@ -207,7 +262,17 @@ class SurferTarget(Visitor):
         return keys[index]
 
     def __init__(self, tree, line_height=SURFER_LINE_HEIGHT):
-        self.line_height = line_height
+        # Reaches here straight from --target-kwargs, so it is checked
+        # rather than divided by: a zero or a quoted number would
+        # otherwise surface as a ZeroDivisionError or a TypeError
+        # traceback, from inside a height conversion, with no output.
+        try:
+            self.line_height = float(line_height)
+        except (TypeError, ValueError):
+            raise ValueError(f'line_height must be a number, got "{line_height}"') from None
+
+        if self.line_height <= 0:
+            raise ValueError(f"line_height must be positive, got {line_height}")
 
         # Number of rows currently visible. Every row is appended, so
         # this doubles as the index of the next one -- see _add_row.
@@ -268,21 +333,43 @@ class SurferTarget(Visitor):
         :return: the index the row sits at once every header is inserted.
         """
         for entry in self.pending:
-            if entry["header"] is not None:
+            if entry.header is not None:
                 continue
 
             self._focus(index)
-            self.genstr += f"group_marked {entry['word']}\n"
-            entry["header"] = index
+            self.genstr += self._add_command("group_marked", entry.word)
+            entry.header = index
             self.nvisible += 1
             index += 1
 
             # group_marked leaves the new group focused, so this renames
             # it and not one of its rows.
-            if entry["word"] != entry["name"]:
-                self.genstr += f"item_rename {entry['name']}\n"
+            self._rename(entry.word, entry.name)
 
         return index
+
+    @staticmethod
+    def _add_command(command, word):
+        """Write ``command`` with ``word`` as its optional argument.
+
+        The argument is left out entirely when there is no word, which is
+        how Surfer is told an item has no name. Writing it with an empty
+        argument instead is not the same thing: it is a parse error, and
+        the command is dropped.
+        """
+        return f"{command} {word}\n" if word else f"{command}\n"
+
+    def _rename(self, word, name):
+        """Restore the real name of the item just added, if it needs it.
+
+        An empty name needs no rename, and must not get one: ``item_rename``
+        takes the rest of the line, an empty rest is a parse error, and
+        the row would keep whatever the add command named it. That falls
+        out of the comparison -- ``word`` is derived from ``name``, so an
+        empty ``name`` yields an empty ``word`` and the two are equal.
+        """
+        if word != name:
+            self.genstr += f"item_rename {name}\n"
 
     def _add_row(self, command):
         """Emit a command that appends one row, and focus that row.
@@ -341,13 +428,18 @@ class SurferTarget(Visitor):
         """
 
         name = command_text(tree.value[0], f"{tree.filename}:{tree.line}")
-        entry = {"name": name, "word": bare_word(name, "group"), "header": None}
+        entry = PendingGroup(name)
 
         self.pending.append(entry)
         super().process_group(tree)
-        self.pending.remove(entry)
 
-        if entry["header"] is None:
+        # Pop rather than remove: groups are entered and left in order,
+        # so this entry is the last one -- and remove() would compare by
+        # value, which two same-named groups satisfy, unregistering the
+        # wrong one.
+        assert self.pending.pop() is entry
+
+        if entry.header is None:
             LOGGER.warning(
                 '%s:%i: group "%s" holds no row and was not created', tree.filename, tree.line, tree.value[0]
             )
@@ -355,11 +447,21 @@ class SurferTarget(Visitor):
 
         # Folding is how the target leaves a group: Surfer inserts into a
         # focused group when it is unfolded and after it when it is not,
-        # so folding the finished group puts the next sibling back at the
+        # so a folded group takes the next sibling after itself, at the
         # enclosing level. group_unfold_all in the footer undoes it.
-        self._focus(entry["header"])
+        self._focus(entry.header)
         self.genstr += "group_fold_recursive\n"
-        self.nvisible = entry["header"] + 1
+        self.nvisible = entry.header + 1
+
+        # Folding drops the focus. GroupFoldRecursive clears focused_item
+        # whenever the folded group contains the focused row, and
+        # subtree_contains(root, candidate) holds for root == candidate,
+        # so focusing the group in order to fold it is exactly what makes
+        # Surfer forget it. Without this second focus the next row is
+        # appended at the end of the tree at level 0, which silently
+        # matches the intent for a top-level group and breaks every
+        # nested one.
+        self._focus(entry.header)
 
     def process_divider(self, tree):
         """Method to process an ast.Divider node.
@@ -368,12 +470,10 @@ class SurferTarget(Visitor):
         """
 
         name = command_text(tree.value[0], f"{tree.filename}:{tree.line}")
-        word = bare_word(name, "divider")
+        word = bare_word(name)
 
-        self._add_row(f"\ndivider_add {word}\n")
-
-        if word != name:
-            self.genstr += f"item_rename {name}\n"
+        self._add_row("\n" + self._add_command("divider_add", word))
+        self._rename(word, name)
 
         # No radix: a divider carries no value to format.
         self._properties(tree, formats=False)
@@ -393,7 +493,13 @@ class SurferTarget(Visitor):
             path = tree.hierarchy.split("/")[1:] + value.split("/")
             fullname = ".".join(path)
 
-            self._add_row(f"variable_add {command_text(fullname, f'{tree.filename}:{tree.line}')}\n")
+            # Dropped rather than substituted: an altered path names a
+            # signal that is not in the dump, and Surfer would add no row
+            # where this file counted one.
+            if not representable_path(fullname, f"{tree.filename}:{tree.line}"):
+                continue
+
+            self._add_row(f"variable_add {fullname}\n")
             self._properties(tree)
 
         super().process_disp(tree)

--- a/wavedisp/targets/surfer.py
+++ b/wavedisp/targets/surfer.py
@@ -17,7 +17,7 @@
 #
 # Copyright (C) 2019 Christophe Clienti
 
-"""Generator for the Surfer viewer.
+"""Target for the Surfer viewer.
 
 Surfer has no scripting language. A command file is a flat list of the
 same commands the in-application prompt accepts, replayed once the
@@ -130,7 +130,7 @@ def height_scale(height, line_height, context):
 
 
 class SurferTarget(Visitor):
-    """Code generator for the Surfer viewer.
+    """Target for the Surfer viewer.
 
     :param tree: AST tree instance.
     :param float line_height: pixel height of one Surfer row, used to

--- a/wavedisp/targets/surfer.py
+++ b/wavedisp/targets/surfer.py
@@ -92,8 +92,53 @@ def bare_word(text, fallback):
     return word if word else fallback
 
 
+#: Surfer's ``layout.waveforms_line_height`` default, in pixels. It is
+#: the only thing a height has to be divided by: a row is drawn
+#: ``waveforms_line_height * height_scaling_factor`` tall, with no
+#: clamping, so the ratio reproduces the requested pixel height exactly.
+#: A user who sets a different value in their own Surfer configuration
+#: has to say so -- see the ``line_height`` argument of SurferTarget.
+SURFER_LINE_HEIGHT = 16.0
+
+
+def height_scale(height, line_height, context):
+    """Convert a row height in pixels to the multiple Surfer expects.
+
+    ``height`` is the property as the other targets read it: Modelsim and
+    RivieraPro pass it to ``add wave -height`` as a pixel count. Surfer
+    has no pixel form, only a factor on its configured line height, so
+    the two only agree through this division.
+
+    :return: the factor, or None if the height is not a usable number.
+    """
+    try:
+        pixels = float(height)
+    except (TypeError, ValueError):
+        LOGGER.error('%s: height "%s" is not a number', context, height)
+        return None
+
+    if pixels <= 0:
+        LOGGER.error('%s: height "%s" is not positive', context, height)
+        return None
+
+    scale = pixels / line_height
+
+    # Trim the representation rather than the value: Surfer parses the
+    # argument as an f32, so 2 and 2.0 are the same row, and 1.875 has to
+    # survive intact.
+    return f"{scale:.4f}".rstrip("0").rstrip(".")
+
+
 class SurferTarget(Visitor):
-    """Code generator for the Surfer viewer."""
+    """Code generator for the Surfer viewer.
+
+    :param tree: AST tree instance.
+    :param float line_height: pixel height of one Surfer row, used to
+        convert the ``height`` property. Defaults to Surfer's own
+        default; override it to match a configuration that sets
+        ``layout.waveforms_line_height`` to something else.
+
+    """
 
     RadixDict = {
         "binary": "Binary",
@@ -161,7 +206,9 @@ class SurferTarget(Visitor):
 
         return keys[index]
 
-    def __init__(self, tree):
+    def __init__(self, tree, line_height=SURFER_LINE_HEIGHT):
+        self.line_height = line_height
+
         # Number of rows currently visible. Every row is appended, so
         # this doubles as the index of the next one -- see _add_row.
         self.nvisible = 0
@@ -256,7 +303,13 @@ class SurferTarget(Visitor):
         return index
 
     def _properties(self, tree, formats=True):
-        """Emit the appearance commands for the focused row."""
+        """Emit the appearance commands for the focused row.
+
+        ``formats`` is cleared for a divider: it carries no value to
+        format, and Surfer's height applies to variables only --
+        ``set_height_scaling_factor`` ignores every other kind of item,
+        so emitting it there would be a silent no-op.
+        """
 
         if formats and "radix" in tree.properties:
             radix = tree.properties["radix"]
@@ -274,15 +327,12 @@ class SurferTarget(Visitor):
                 except KeyError:
                     LOGGER.error('%s:%i: unkown color "%s"', tree.filename, tree.line, color)
 
-        if "height" in tree.properties:
+        if formats and "height" in tree.properties:
             height = tree.properties["height"]
             if height != "":
-                # Modelsim and RivieraPro read this as a pixel height,
-                # Surfer as a multiple of the line height -- it suggests
-                # 1, 2, 4, 8 and 16. The value is passed through as it
-                # stands; a height written for Modelsim will be enormous
-                # here.
-                self.genstr += f"item_set_height {height}\n"
+                scale = height_scale(height, self.line_height, f"{tree.filename}:{tree.line}")
+                if scale is not None:
+                    self.genstr += f"item_set_height {scale}\n"
 
     def process_group(self, tree):
         """Method to process an ast.Group node.

--- a/wavedisp/targets/surfer.py
+++ b/wavedisp/targets/surfer.py
@@ -1,0 +1,349 @@
+#
+# This file is part of wavedisp. See the root README.md for further
+# information.
+#
+# wavedisp is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wavedisp is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with wavedisp. If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (C) 2019 Christophe Clienti
+
+"""Generator for the Surfer viewer.
+
+Surfer has no scripting language. A command file is a flat list of the
+same commands the in-application prompt accepts, replayed once the
+waveform is loaded, and every command that changes an item acts on the
+*focused* item rather than on a named one. The whole target is therefore
+built around one invariant:
+
+    after each emitted row, focus is on that row and its visible index
+    is known.
+
+The index is tracked here rather than read back, because the command
+language cannot read anything back -- there is no equivalent of
+gtkwave's ``getTotalNumTraces``. See ``_focus`` for what that costs.
+"""
+
+import logging
+import re
+
+from ..visitor import Visitor
+from .x11colors import X11_COLORS
+
+LOGGER = logging.getLogger("wavegen")
+
+
+def alpha_idx(index):
+    """Return the identifier Surfer uses to name the row at ``index``.
+
+    ``item_focus`` does not take a number: Surfer formats the index as
+    hexadecimal and maps the digits onto ``a``-``p``, which is what it
+    displays next to each row. Surfer zero-pads that identifier to the
+    width of the longest one, but its parser reads the digits as plain
+    hexadecimal, so an unpadded identifier selects the same row.
+    """
+    return "".join(chr(ord("a") + int(digit, 16)) for digit in f"{index:x}")
+
+
+def command_text(text, context):
+    """Return ``text`` as a Surfer command file can carry it.
+
+    A command file is split on newlines and on ``;``, and everything
+    after a ``#`` is dropped, before any command is parsed. Those two
+    characters are removed by the splitter itself, and the splitter has
+    no quoting or escaping whatsoever -- there is no spelling of a name
+    containing them that survives. They are replaced here so the rest of
+    the file still parses, and reported, since the result is not what the
+    user asked for.
+    """
+    if "#" in text or ";" in text:
+        LOGGER.error(
+            '%s: "#" and ";" cannot be represented in a Surfer command file, replaced by "_" in "%s"', context, text
+        )
+        text = text.replace("#", "_").replace(";", "_")
+
+    return text
+
+
+def bare_word(text, fallback):
+    """Return ``text`` reduced to what ``divider_add`` and ``group_marked`` accept.
+
+    Those two take an *optional* argument, which Surfer parses as a
+    single word: it matches ``\\w*`` and then fails the whole line with
+    "extra parameters" if anything is left over. So a name as ordinary as
+    ``reg 0`` does not add a divider with a truncated name, it adds no
+    divider at all.
+
+    The caller pairs this with an ``item_rename``, which takes the rest
+    of the line and restores the real name -- the reduced word is never
+    what ends up on screen.
+    """
+    word = re.sub(r"\W+", "_", text, flags=re.ASCII).strip("_")
+
+    return word if word else fallback
+
+
+class SurferTarget(Visitor):
+    """Code generator for the Surfer viewer."""
+
+    RadixDict = {
+        "binary": "Binary",
+        "hexadecimal": "Hexadecimal",
+        "signed": "Signed",
+        "unsigned": "Unsigned",
+        "octal": "Octal",
+        "string": "String",
+        "symbolic": "Enum",
+    }
+
+    #: Surfer takes a colour *name*, resolved against the active theme,
+    #: not a value. These are the names of the default theme, shared by
+    #: ``light+`` and the three ``rose-pine`` variants; the other bundled
+    #: themes define different sets, and a name they do not define leaves
+    #: the item at its default colour.
+    SupportedColors = {
+        "Green": (0x6A, 0x99, 0x55),
+        "Red": (0xF4, 0x47, 0x47),
+        "Yellow": (0xFF, 0xD6, 0x02),
+        "Blue": (0x56, 0x9C, 0xD6),
+        "Pink": (0xC5, 0x86, 0xC0),
+        "Orange": (0xCE, 0x91, 0x78),
+        "Gray": (0x80, 0x80, 0x80),
+        "Violet": (0x64, 0x66, 0x95),
+    }
+
+    @staticmethod
+    def nearest_color(color):
+        """Return the nearest color.
+
+        Surfer only knows the colors named by the active theme, so a
+        color from the X11_COLORS dictionary has to be matched to one of
+        them. A L2 distance on RGB values is used to found the best color
+        match, as for the GTKWave target.
+
+        The name is tried first, because the theme colors are muted
+        rather than primary and the distance alone reads them badly:
+        Surfer's "Blue" is #569cd6, far enough from pure blue that
+        ``color='blue'`` comes out as Violet.
+
+        :param str color: input color string from the X11_COLORS dictionary.
+
+        :return: a color string from the Surfer SupportedColors dictionary keys.
+
+        """
+
+        lookup_color = X11_COLORS[color]
+
+        for key in SurferTarget.SupportedColors:
+            if key.lower() == color.lower():
+                return key
+
+        keys = list(SurferTarget.SupportedColors.keys())
+
+        distance_list = []
+        for key in keys:
+            value = SurferTarget.SupportedColors[key]
+            distance = (value[0] - lookup_color[0]) ** 2
+            distance += (value[1] - lookup_color[1]) ** 2
+            distance += (value[2] - lookup_color[2]) ** 2
+            distance_list.append(distance)
+
+        index = distance_list.index(min(distance_list))
+
+        return keys[index]
+
+    def __init__(self, tree):
+        # Number of rows currently visible. Every row is appended, so
+        # this doubles as the index of the next one -- see _add_row.
+        self.nvisible = 0
+
+        # Groups entered but not yet created, outermost first. A group
+        # cannot be created empty, so each one latches onto the first row
+        # emitted inside it.
+        self.pending = []
+
+        self.genstr = "# Wavedisp generated Surfer command file\n"
+
+        self.visit(tree)
+
+        # Every group was folded as it was closed, which is how the
+        # target returns to the enclosing level. Undo that, and leave
+        # nothing focused so the view does not open on the last row.
+        if "group_marked" in self.genstr:
+            self.genstr += "\ngroup_unfold_all\n"
+            self.genstr += "item_unfocus\n"
+        else:
+            self.genstr += "\nitem_unfocus\n"
+
+    def _focus(self, index):
+        """Focus the row at ``index``, which every later command acts on.
+
+        This is where the target is fragile, and it cannot be made
+        otherwise: the index is the one *this* file predicts, so a
+        ``variable_add`` that adds no row -- a signal absent from the
+        dump, most likely -- shifts every later row by one and every
+        later command lands on the wrong one. Surfer logs the failed add,
+        and ``dump_tree`` prints the resulting tree; there is no way to
+        recover inside the command file.
+        """
+        command = f"item_focus {alpha_idx(index)}\n"
+
+        # Closing a group focuses its header right after the last row
+        # inside it was focused. Nothing ran in between, so the earlier
+        # focus had no effect and only makes the file harder to read.
+        previous = self.genstr.rsplit("\n", 2)[-2] if self.genstr.count("\n") > 1 else ""
+        if previous.startswith("item_focus "):
+            self.genstr = self.genstr[: -len(previous) - 1] + command
+        else:
+            self.genstr += command
+
+    def _create_pending_groups(self, index):
+        """Create the groups waiting for a first row, around the row at ``index``.
+
+        ``group_marked`` moves the focused item into a new group -- only
+        the focused item, since selecting several rows is a mouse and
+        keyboard action with no command behind it. A group is therefore
+        built by creating it around its first row and letting the rest be
+        inserted into it afterwards.
+
+        Outermost first: each creation inserts a header just above the
+        row, so building A before B nests B inside A.
+
+        :return: the index the row sits at once every header is inserted.
+        """
+        for entry in self.pending:
+            if entry["header"] is not None:
+                continue
+
+            self._focus(index)
+            self.genstr += f"group_marked {entry['word']}\n"
+            entry["header"] = index
+            self.nvisible += 1
+            index += 1
+
+            # group_marked leaves the new group focused, so this renames
+            # it and not one of its rows.
+            if entry["word"] != entry["name"]:
+                self.genstr += f"item_rename {entry['name']}\n"
+
+        return index
+
+    def _add_row(self, command):
+        """Emit a command that appends one row, and focus that row.
+
+        Focus is what the next insertion is placed after, so it is set
+        explicitly rather than left to Surfer moving it on its own: a
+        command file that only ever relies on ``item_focus`` depends on
+        one documented command instead of on where an item happens to
+        land.
+        """
+        index = self.nvisible
+        self.genstr += command
+        self.nvisible += 1
+
+        index = self._create_pending_groups(index)
+        self._focus(index)
+
+        return index
+
+    def _properties(self, tree, formats=True):
+        """Emit the appearance commands for the focused row."""
+
+        if formats and "radix" in tree.properties:
+            radix = tree.properties["radix"]
+            if radix != "":
+                try:
+                    self.genstr += f"item_set_format {self.RadixDict[radix]}\n"
+                except KeyError:
+                    LOGGER.error('%s:%i: unkown radix type "%s"', tree.filename, tree.line, radix)
+
+        if "color" in tree.properties:
+            color = tree.properties["color"]
+            if color != "":
+                try:
+                    self.genstr += f"item_set_color {self.nearest_color(color)}\n"
+                except KeyError:
+                    LOGGER.error('%s:%i: unkown color "%s"', tree.filename, tree.line, color)
+
+        if "height" in tree.properties:
+            height = tree.properties["height"]
+            if height != "":
+                # Modelsim and RivieraPro read this as a pixel height,
+                # Surfer as a multiple of the line height -- it suggests
+                # 1, 2, 4, 8 and 16. The value is passed through as it
+                # stands; a height written for Modelsim will be enormous
+                # here.
+                self.genstr += f"item_set_height {height}\n"
+
+    def process_group(self, tree):
+        """Method to process an ast.Group node.
+
+        :param tree: AST tree instance.
+        """
+
+        name = command_text(tree.value[0], f"{tree.filename}:{tree.line}")
+        entry = {"name": name, "word": bare_word(name, "group"), "header": None}
+
+        self.pending.append(entry)
+        super().process_group(tree)
+        self.pending.remove(entry)
+
+        if entry["header"] is None:
+            LOGGER.warning(
+                '%s:%i: group "%s" holds no row and was not created', tree.filename, tree.line, tree.value[0]
+            )
+            return
+
+        # Folding is how the target leaves a group: Surfer inserts into a
+        # focused group when it is unfolded and after it when it is not,
+        # so folding the finished group puts the next sibling back at the
+        # enclosing level. group_unfold_all in the footer undoes it.
+        self._focus(entry["header"])
+        self.genstr += "group_fold_recursive\n"
+        self.nvisible = entry["header"] + 1
+
+    def process_divider(self, tree):
+        """Method to process an ast.Divider node.
+
+        :param tree: AST tree instance.
+        """
+
+        name = command_text(tree.value[0], f"{tree.filename}:{tree.line}")
+        word = bare_word(name, "divider")
+
+        self._add_row(f"\ndivider_add {word}\n")
+
+        if word != name:
+            self.genstr += f"item_rename {name}\n"
+
+        # No radix: a divider carries no value to format.
+        self._properties(tree, formats=False)
+
+        super().process_divider(tree)
+
+    def process_disp(self, tree):
+        """Method to process an ast.Disp node.
+
+        :param tree: AST tree instance.
+        """
+
+        for value in tree.value:
+            # Surfer separates scopes with dots. The separator is applied
+            # to the signal name too, since a Disp value is allowed to
+            # carry a path of its own -- Disp('reset_inst/pcie_rstn').
+            path = tree.hierarchy.split("/")[1:] + value.split("/")
+            fullname = ".".join(path)
+
+            self._add_row(f"variable_add {command_text(fullname, f'{tree.filename}:{tree.line}')}\n")
+            self._properties(tree)
+
+        super().process_disp(tree)

--- a/wavedisp/targets/surfer.py
+++ b/wavedisp/targets/surfer.py
@@ -283,18 +283,36 @@ class SurferTarget(Visitor):
         # emitted inside it.
         self.pending = []
 
-        self.genstr = "# Wavedisp generated Surfer command file\n"
+        # Emitted commands, joined on demand. A list rather than a
+        # string so that the _focus peephole is a look at the last entry
+        # instead of a scan of everything written so far, which turned
+        # generation quadratic in the number of rows.
+        self._chunks = ["# Wavedisp generated Surfer command file\n"]
+
+        # Whether any group was created, for the footer. Recovering it by
+        # searching the output for "group_marked" would also find the
+        # word inside a name.
+        self._grouped = False
 
         self.visit(tree)
 
         # Every group was folded as it was closed, which is how the
         # target returns to the enclosing level. Undo that, and leave
         # nothing focused so the view does not open on the last row.
-        if "group_marked" in self.genstr:
-            self.genstr += "\ngroup_unfold_all\n"
-            self.genstr += "item_unfocus\n"
+        if self._grouped:
+            self._emit("\ngroup_unfold_all\n")
+            self._emit("item_unfocus\n")
         else:
-            self.genstr += "\nitem_unfocus\n"
+            self._emit("\nitem_unfocus\n")
+
+    @property
+    def genstr(self):
+        """The generated command file."""
+        return "".join(self._chunks)
+
+    def _emit(self, text):
+        """Append ``text`` to the output."""
+        self._chunks.append(text)
 
     def _focus(self, index):
         """Focus the row at ``index``, which every later command acts on.
@@ -312,11 +330,12 @@ class SurferTarget(Visitor):
         # Closing a group focuses its header right after the last row
         # inside it was focused. Nothing ran in between, so the earlier
         # focus had no effect and only makes the file harder to read.
-        previous = self.genstr.rsplit("\n", 2)[-2] if self.genstr.count("\n") > 1 else ""
-        if previous.startswith("item_focus "):
-            self.genstr = self.genstr[: -len(previous) - 1] + command
+        # _focus is the only thing that emits this command, and always
+        # as a chunk of its own, so the last chunk is the whole test.
+        if self._chunks[-1].startswith("item_focus "):
+            self._chunks[-1] = command
         else:
-            self.genstr += command
+            self._emit(command)
 
     def _create_pending_groups(self, index):
         """Create the groups waiting for a first row, around the row at ``index``.
@@ -337,7 +356,8 @@ class SurferTarget(Visitor):
                 continue
 
             self._focus(index)
-            self.genstr += self._add_command("group_marked", entry.word)
+            self._emit(self._add_command("group_marked", entry.word))
+            self._grouped = True
             entry.header = index
             self.nvisible += 1
             index += 1
@@ -369,7 +389,7 @@ class SurferTarget(Visitor):
         empty ``name`` yields an empty ``word`` and the two are equal.
         """
         if word != name:
-            self.genstr += f"item_rename {name}\n"
+            self._emit(f"item_rename {name}\n")
 
     def _add_row(self, command):
         """Emit a command that appends one row, and focus that row.
@@ -381,7 +401,7 @@ class SurferTarget(Visitor):
         land.
         """
         index = self.nvisible
-        self.genstr += command
+        self._emit(command)
         self.nvisible += 1
 
         index = self._create_pending_groups(index)
@@ -402,7 +422,7 @@ class SurferTarget(Visitor):
             radix = tree.properties["radix"]
             if radix != "":
                 try:
-                    self.genstr += f"item_set_format {self.RadixDict[radix]}\n"
+                    self._emit(f"item_set_format {self.RadixDict[radix]}\n")
                 except KeyError:
                     LOGGER.error('%s:%i: unkown radix type "%s"', tree.filename, tree.line, radix)
 
@@ -410,7 +430,7 @@ class SurferTarget(Visitor):
             color = tree.properties["color"]
             if color != "":
                 try:
-                    self.genstr += f"item_set_color {self.nearest_color(color)}\n"
+                    self._emit(f"item_set_color {self.nearest_color(color)}\n")
                 except KeyError:
                     LOGGER.error('%s:%i: unkown color "%s"', tree.filename, tree.line, color)
 
@@ -419,7 +439,7 @@ class SurferTarget(Visitor):
             if height != "":
                 scale = height_scale(height, self.line_height, f"{tree.filename}:{tree.line}")
                 if scale is not None:
-                    self.genstr += f"item_set_height {scale}\n"
+                    self._emit(f"item_set_height {scale}\n")
 
     def process_group(self, tree):
         """Method to process an ast.Group node.
@@ -437,7 +457,13 @@ class SurferTarget(Visitor):
         # so this entry is the last one -- and remove() would compare by
         # value, which two same-named groups satisfy, unregistering the
         # wrong one.
-        assert self.pending.pop() is entry
+        #
+        # Not an assert, because the pop is the point and `python -O`
+        # deletes the whole statement: the entry would stay pending and
+        # latch onto some later row, wrapping it in a group the wave file
+        # never asked for.
+        if self.pending.pop() is not entry:
+            raise RuntimeError("groups were left in a different order than they were entered")
 
         if entry.header is None:
             LOGGER.warning(
@@ -450,7 +476,7 @@ class SurferTarget(Visitor):
         # so a folded group takes the next sibling after itself, at the
         # enclosing level. group_unfold_all in the footer undoes it.
         self._focus(entry.header)
-        self.genstr += "group_fold_recursive\n"
+        self._emit("group_fold_recursive\n")
         self.nvisible = entry.header + 1
 
         # Folding drops the focus. GroupFoldRecursive clears focused_item

--- a/wavedisp/targets/surfer.py
+++ b/wavedisp/targets/surfer.py
@@ -34,9 +34,11 @@ gtkwave's ``getTotalNumTraces``. See ``_focus`` for what that costs.
 """
 
 import logging
+import math
 import re
 
 from ..visitor import Visitor
+from . import TargetOptionError
 from .x11colors import X11_COLORS
 
 LOGGER = logging.getLogger("wavegen")
@@ -54,11 +56,11 @@ def alpha_idx(index):
     return "".join(chr(ord("a") + int(digit, 16)) for digit in f"{index:x}")
 
 
-#: The characters a command file cannot carry anywhere, at all. It is
-#: split into lines, then on ``;``, then truncated at ``#``, before any
-#: command is parsed, and the splitter has no quoting or escaping -- so
-#: there is no spelling of a name or a path containing one of these that
-#: survives.
+#: The characters a command file cannot carry anywhere, at all. Each
+#: line is trimmed, truncated at the first ``#``, then split on ``;``,
+#: all before any command is parsed, and none of it can be quoted or
+#: escaped -- so there is no spelling of a name or a path containing one
+#: of these that survives.
 UNREPRESENTABLE = "#;\n\r"
 
 
@@ -266,13 +268,23 @@ class SurferTarget(Visitor):
         # rather than divided by: a zero or a quoted number would
         # otherwise surface as a ZeroDivisionError or a TypeError
         # traceback, from inside a height conversion, with no output.
+        # bool first: it is a subclass of int, so float(True) is 1.0 and
+        # a json `true` would quietly become a 1-pixel line height.
+        if isinstance(line_height, bool):
+            raise TargetOptionError(f"line_height must be a number, got {line_height}")
+
         try:
             self.line_height = float(line_height)
         except (TypeError, ValueError):
-            raise ValueError(f'line_height must be a number, got "{line_height}"') from None
+            raise TargetOptionError(f'line_height must be a number, got "{line_height}"') from None
+
+        # Python's json accepts the non-standard Infinity and NaN, and
+        # neither is caught by a comparison: nan <= 0 is False.
+        if not math.isfinite(self.line_height):
+            raise TargetOptionError(f"line_height must be finite, got {line_height}")
 
         if self.line_height <= 0:
-            raise ValueError(f"line_height must be positive, got {line_height}")
+            raise TargetOptionError(f"line_height must be positive, got {line_height}")
 
         # Number of rows currently visible. Every row is appended, so
         # this doubles as the index of the next one -- see _add_row.
@@ -358,6 +370,13 @@ class SurferTarget(Visitor):
             self._focus(index)
             self._emit(self._add_command("group_marked", entry.word))
             self._grouped = True
+
+            # An unnamed group is the one thing Surfer will not do: with
+            # no argument group_marked passes None on and add_group
+            # substitutes the literal "Group", and the rename that would
+            # fix it cannot carry an empty name either.
+            if not entry.name.strip():
+                LOGGER.warning('Surfer cannot leave a group unnamed, it will read "Group"')
             entry.header = index
             self.nvisible += 1
             index += 1
@@ -382,12 +401,15 @@ class SurferTarget(Visitor):
     def _rename(self, word, name):
         """Restore the real name of the item just added, if it needs it.
 
-        An empty name needs no rename, and must not get one: ``item_rename``
-        takes the rest of the line, an empty rest is a parse error, and
-        the row would keep whatever the add command named it. That falls
-        out of the comparison -- ``word`` is derived from ``name``, so an
-        empty ``name`` yields an empty ``word`` and the two are equal.
+        A name that is empty or only whitespace cannot be sent at all:
+        Surfer trims each line before parsing it, so the argument is gone
+        and ``item_rename`` fails with "missing parameters". The command
+        is left out rather than emitted and rejected -- the add command
+        has already left the item unnamed.
         """
+        if not name.strip():
+            return
+
         if word != name:
             self._emit(f"item_rename {name}\n")
 


### PR DESCRIPTION
Adds a `surfer` target alongside gtkwave/modelsim/rivierapro:

```sh
wavedisp -t surfer -o my_tb.sucl my_tb.wave.py
surfer my_tb.vcd --command-file my_tb.sucl
```

## What made this different from the other targets

Surfer has no scripting language. A command file is a flat list of the
commands the in-app prompt accepts, and **every command that changes an
item acts on the focused item** — there is no way to name one, and no way
to read anything back (no equivalent of gtkwave's `getTotalNumTraces`).
The target therefore predicts each row's index and emits `item_focus`.

Groups are the hard part. `group_marked` groups the focused item plus the
*selected* ones, and selecting rows is a mouse/keyboard action with no
command behind it — so from a command file it groups exactly one row.
A group is built by creating it around its first row and letting the rest
be inserted into it (Surfer inserts *inside* a focused group when
unfolded), then folding it to return to the enclosing level (Surfer
inserts *after* a focused group when folded). `group_unfold_all` in the
footer restores the view.

## Surfer limits that surface to the user

| Limit | Handling |
|---|---|
| Command files are split on `;` and truncated at `#`, with no quoting at all | replaced by `_`, reported as an error |
| `divider_add` / `group_marked` take one `\w+` word — `reg 0` fails the whole line rather than truncating | added under a reduced word, then `item_rename` (which takes the rest of the line) restores the real name |
| Colour names resolve against the active theme | matched by name first, nearest-RGB otherwise; documented that non-default themes define other names |
| `item_set_height` is a line-height multiple | passed through, documented as differing from Modelsim's pixels |
| A missing signal adds no row and shifts every later index | documented; `dump_tree` diagnoses it |

## Rejected alternatives

- **State file (`--state-file`, RON).** Expresses nesting directly and
  needs none of the focus dance, but it is a serde dump of Surfer's
  internal `UserState` — the command list is the interface, the struct is
  not, and Surfer is 0.x with breaking changes expected every six weeks.
- **Flattening groups into dividers.** Robust and trivial, but the group
  is what keeps a large default view usable.

## Verification

Run against **surfer 0.7.0 (dffac68)**, not just modelled:

- `dump_tree` shows the expected tree — nested groups, a divider opening a
  group, names with spaces, rows returning to the outer level;
- `save_state_as` confirms each format/colour landed on its own row,
  including a signal displayed twice where only the second is coloured.

`tests/test_surfer_replay.py` restates Surfer's insertion rules and
replays the generated file through them, because a wrong index produces a
file that is still valid and quietly builds the wrong tree. Six
deliberate mutations of the target (fold arithmetic, nesting order,
header index, missing re-focus, alpha encoding, missing fold) are all
caught.